### PR TITLE
Migrate to Fly.io + Modal + Turbopuffer

### DIFF
--- a/.github/workflows/deploy-fly.yaml
+++ b/.github/workflows/deploy-fly.yaml
@@ -121,7 +121,6 @@ jobs:
             ${{ env.REGISTRY }}/migrate:${{ needs.setup.outputs.version_tag }} \
             --app corpus-api \
             --rm \
-            --env DATABASE_URL="${{ secrets.DATABASE_URL }}" \
             -- alembic upgrade head
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy-fly.yaml
+++ b/.github/workflows/deploy-fly.yaml
@@ -1,0 +1,180 @@
+name: Deploy to Fly.io
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: false
+        default: "production"
+
+env:
+  REGISTRY: ghcr.io/noetic-sys/corpus
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      version_tag: ${{ steps.tag.outputs.new_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create version tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag_prefix: v
+
+  build-and-push:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - name: api
+            dockerfile: ./backend/api/Dockerfile
+            context: .
+          - name: agent
+            dockerfile: ./backend/api/Dockerfile
+            context: .
+          - name: worker
+            dockerfile: ./backend/workers/Dockerfile
+            context: .
+          - name: migrate
+            dockerfile: ./backend/alembic/Dockerfile
+            context: .
+          - name: workflow-agent
+            dockerfile: ./agents/workflow/Dockerfile
+            context: .
+          - name: agent-qa
+            dockerfile: ./agents/qa/Dockerfile
+            context: .
+          - name: document-chunker
+            dockerfile: ./agents/chunking/Dockerfile
+            context: .
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Generate frontend environment file
+        if: matrix.image.name == 'frontend'
+        run: |
+          cat > vite/.env.production << EOF
+          VITE_API_URL=${{ secrets.VITE_API_URL }}
+          VITE_WS_URL=${{ secrets.VITE_WS_URL }}
+          VITE_FIREBASE_API_KEY=${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN=${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID=${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          EOF
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.image.name }}
+          tags: |
+            type=raw,value=${{ needs.setup.outputs.version_tag }}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  migrate:
+    needs: [setup, build-and-push]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Run database migrations
+        run: |
+          flyctl machines run \
+            ${{ env.REGISTRY }}/migrate:${{ needs.setup.outputs.version_tag }} \
+            --app corpus-api \
+            --rm \
+            --env DATABASE_URL="${{ secrets.DATABASE_URL }}" \
+            -- alembic upgrade head
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy:
+    needs: [setup, build-and-push, migrate]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - name: corpus-api
+            config: fly-deploy/api.toml
+            image: api
+          - name: corpus-agent
+            config: fly-deploy/agent.toml
+            image: agent
+          - name: corpus-worker-qa
+            config: fly-deploy/worker-qa.toml
+            image: worker
+          - name: corpus-worker-document-indexing
+            config: fly-deploy/worker-document-indexing.toml
+            image: worker
+          - name: corpus-temporal-routing
+            config: fly-deploy/worker-temporal-routing.toml
+            image: worker
+          - name: corpus-temporal-pdf
+            config: fly-deploy/worker-temporal-pdf.toml
+            image: worker
+          - name: corpus-temporal-page
+            config: fly-deploy/worker-temporal-page.toml
+            image: worker
+          - name: corpus-temporal-generic
+            config: fly-deploy/worker-temporal-generic.toml
+            image: worker
+          - name: corpus-temporal-chunking
+            config: fly-deploy/worker-temporal-chunking.toml
+            image: worker
+          - name: corpus-temporal-workflow
+            config: fly-deploy/worker-temporal-workflow.toml
+            image: worker
+          - name: corpus-temporal-qa
+            config: fly-deploy/worker-temporal-qa.toml
+            image: worker
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy ${{ matrix.service.name }}
+        run: |
+          flyctl deploy \
+            --config ${{ matrix.service.config }} \
+            --image ${{ env.REGISTRY }}/${{ matrix.service.image }}:${{ needs.setup.outputs.version_tag }} \
+            --app ${{ matrix.service.name }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ build/
 .env
 .env.local
 .env.*.local
+scripts/.env.fly
 
 # Logs
 *.log

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,9 @@
 # Environment Profile ("local" or "production")
-# Controls storage provider (S3 vs GCS), workflow execution (Docker vs K8s), CORS origins, etc.
+# Controls workflow execution (Docker vs K8s), CORS origins, etc.
 ENVIRONMENT=local
+
+# Storage provider ("s3" or "gcs") — s3 works with LocalStack, R2, MinIO, etc.
+STORAGE_PROVIDER=s3
 
 # API Settings
 APP_NAME="Corpus Service"

--- a/backend/common/core/config.py
+++ b/backend/common/core/config.py
@@ -32,12 +32,15 @@ class Settings(BaseSettings):
         """Construct database URL from components."""
         return f"postgresql://{self.db_user}:{self.db_password}@{self.db_host}:{self.db_port}/{self.db_name}"
 
-    # AWS/S3
+    # Storage provider (s3 or gcs — set STORAGE_PROVIDER env var to override)
+    storage_provider: StorageProvider = StorageProvider.GCS
+
+    # AWS/S3 (also used for S3-compatible backends like Cloudflare R2)
     aws_access_key_id: str
     aws_secret_access_key: str
     aws_region: str
     s3_bucket_name: str
-    s3_endpoint_url: Optional[str] = None  # For LocalStack
+    s3_endpoint_url: Optional[str] = None  # For LocalStack / R2
 
     # RabbitMQ
     rabbitmq_host: str
@@ -125,6 +128,7 @@ class Settings(BaseSettings):
     elasticsearch_username: Optional[str] = None
     elasticsearch_password: Optional[str] = None
     elasticsearch_scheme: str = "http"
+    turbopuffer_api_key: Optional[str] = None
 
     @property
     def elasticsearch_url(self) -> str:
@@ -154,15 +158,6 @@ class Settings(BaseSettings):
     )
 
     # Environment-aware properties
-    @property
-    def storage_provider(self) -> StorageProvider:
-        """Auto-select storage provider based on environment."""
-        return (
-            StorageProvider.S3
-            if self.environment == Environment.LOCAL
-            else StorageProvider.GCS
-        )
-
     @property
     def workflow_execution_mode(self) -> WorkflowExecutionMode:
         """Auto-select workflow execution mode based on environment."""

--- a/backend/common/core/config.py
+++ b/backend/common/core/config.py
@@ -105,7 +105,7 @@ class Settings(BaseSettings):
     temporal_host: str
     temporal_namespace: str = "default"
     temporal_api_key: Optional[str] = None
-    temporal_task_queue: str
+    temporal_task_queue: Optional[str] = None
 
     # Google Gemini
     gemini_api_keys: List[str]

--- a/backend/common/core/config.py
+++ b/backend/common/core/config.py
@@ -156,23 +156,9 @@ class Settings(BaseSettings):
     workflow_agent_image_tag: str = (
         "latest"  # Workflow agent image tag (set by deployment)
     )
+    workflow_execution_mode: WorkflowExecutionMode = WorkflowExecutionMode.DOCKER
 
-    # Environment-aware properties
-    @property
-    def workflow_execution_mode(self) -> WorkflowExecutionMode:
-        """Auto-select workflow execution mode based on environment."""
-        return (
-            WorkflowExecutionMode.DOCKER
-            if self.environment == Environment.LOCAL
-            else WorkflowExecutionMode.K8S
-        )
-
-    @property
-    def api_endpoint(self) -> str:
-        """Auto-select API endpoint based on environment."""
-        if self.environment == Environment.LOCAL:
-            return "http://backend:8000"
-        return "http://corpus-api:8000"
+    api_endpoint: str = "http://backend:8000"
 
     @property
     def cors_allowed_origins(self) -> List[str]:

--- a/backend/common/core/constants.py
+++ b/backend/common/core/constants.py
@@ -22,3 +22,4 @@ class WorkflowExecutionMode(str, Enum):
 
     DOCKER = "docker"
     K8S = "k8s"
+    MODAL = "modal"

--- a/backend/common/execution/executors/modal_executor.py
+++ b/backend/common/execution/executors/modal_executor.py
@@ -1,0 +1,75 @@
+"""
+Modal executor for serverless job execution.
+
+Manages Modal Sandboxes for agent execution using:
+- Modal Python SDK for Sandbox lifecycle
+- gVisor isolation (same as K8s executor)
+"""
+
+from typing import Dict, Any
+
+import modal
+
+from common.core.config import settings
+from common.execution.executors.base import JobExecutor
+from common.execution.job_spec import JobSpec
+
+
+class ModalExecutor(JobExecutor):
+    """Executor for Modal-based sandbox execution."""
+
+    def __init__(self):
+        """Initialize Modal app handle."""
+        self.app = modal.App.lookup("corpus-agents", create_if_missing=True)
+        self.image_registry = "ghcr.io/noetic-sys/corpus"
+
+    def launch(self, job_spec: JobSpec) -> Dict[str, Any]:
+        """Launch a Modal Sandbox based on job spec."""
+        image_tag = job_spec.image_tag or settings.workflow_agent_image_tag
+        image_ref = f"{self.image_registry}/{job_spec.image_name}:{image_tag}"
+        image = modal.Image.from_registry(image_ref)
+
+        timeout = job_spec.template_vars.get("timeout", 900)
+
+        sb = modal.Sandbox.create(
+            image=image,
+            app=self.app,
+            timeout=timeout,
+            cpu=1.0,
+            memory=1024,
+            env=job_spec.env_vars,
+        )
+
+        return {
+            "mode": "modal",
+            "sandbox_id": sb.object_id,
+            "job_name": job_spec.container_name,
+        }
+
+    def check_status(self, execution_info: Dict[str, Any]) -> Dict[str, Any]:
+        """Check Modal Sandbox status."""
+        sandbox_id = execution_info["sandbox_id"]
+
+        try:
+            sb = modal.Sandbox.from_id(sandbox_id)
+        except Exception:
+            return {"status": "failed", "error": "Sandbox not found"}
+
+        exit_code = sb.poll()
+        if exit_code is None:
+            return {"status": "running"}
+        if exit_code == 0:
+            return {"status": "completed", "exit_code": 0}
+        return {"status": "failed", "exit_code": exit_code}
+
+    def cleanup(self, execution_info: Dict[str, Any]) -> None:
+        """Terminate Modal Sandbox if still running."""
+        sandbox_id = execution_info["sandbox_id"]
+        job_name = execution_info.get("job_name", sandbox_id)
+
+        try:
+            sb = modal.Sandbox.from_id(sandbox_id)
+            sb.terminate()
+            print(f"Terminated Modal sandbox for {job_name}")
+        except Exception:
+            print(f"Sandbox {job_name} already terminated or not found")

--- a/backend/common/execution/workflow_framework/activity_helpers.py
+++ b/backend/common/execution/workflow_framework/activity_helpers.py
@@ -11,6 +11,7 @@ from temporalio import activity
 from common.core.constants import WorkflowExecutionMode
 from common.execution.executors.docker import DockerExecutor
 from common.execution.executors.k8s import K8sExecutor
+from common.execution.executors.modal_executor import ModalExecutor
 
 
 def get_executor():
@@ -18,7 +19,7 @@ def get_executor():
     Get appropriate executor based on execution mode.
 
     Returns:
-        DockerExecutor or K8sExecutor based on settings
+        DockerExecutor, K8sExecutor, or ModalExecutor based on settings
     """
     # Import settings here to avoid workflow sandbox issues
     from common.core.config import settings  # noqa: PLC0415
@@ -26,6 +27,8 @@ def get_executor():
     execution_mode = WorkflowExecutionMode(settings.workflow_execution_mode)
     if execution_mode == WorkflowExecutionMode.DOCKER:
         return DockerExecutor()
+    elif execution_mode == WorkflowExecutionMode.MODAL:
+        return ModalExecutor()
     else:
         return K8sExecutor()
 

--- a/backend/common/providers/messaging/rabbitmq.py
+++ b/backend/common/providers/messaging/rabbitmq.py
@@ -34,6 +34,7 @@ class RabbitMQClient(MessageQueueInterface):
     async def connect(self) -> bool:
         try:
             credentials = pika.PlainCredentials(self.username, self.password)
+            ssl_options = pika.SSLOptions() if self.port == 5671 else None
             parameters = pika.ConnectionParameters(
                 host=self.host,
                 port=self.port,
@@ -41,6 +42,7 @@ class RabbitMQClient(MessageQueueInterface):
                 credentials=credentials,
                 heartbeat=600,
                 blocked_connection_timeout=300,
+                ssl_options=ssl_options,
             )
 
             self.connection = pika.BlockingConnection(parameters)

--- a/backend/common/providers/messaging/rabbitmq_async.py
+++ b/backend/common/providers/messaging/rabbitmq_async.py
@@ -75,7 +75,8 @@ class RabbitMQClient(MessageQueueInterface):
     async def connect(self) -> bool:
         try:
             # Create connection URL
-            url = f"amqp://{quote(self.username)}:{quote(self.password)}@{self.host}:{self.port}/{self.vhost}"
+            scheme = "amqps" if self.port == 5671 else "amqp"
+            url = f"{scheme}://{quote(self.username)}:{quote(self.password)}@{self.host}:{self.port}/{self.vhost}"
 
             # Create robust connection (will auto-reconnect)
             self.connection = await connect_robust(url, loop=asyncio.get_event_loop())

--- a/backend/packages/documents/providers/document_search/factory.py
+++ b/backend/packages/documents/providers/document_search/factory.py
@@ -1,6 +1,7 @@
 from .interface import DocumentSearchInterface
 from .postgres_search import PostgresDocumentSearch
 from .elasticsearch_search import ElasticsearchDocumentSearch
+from .turbopuffer_document_search import TurbopufferDocumentSearch
 from .types import DocumentSearchProvider
 from common.core.config import settings
 
@@ -13,6 +14,8 @@ def get_document_search_provider() -> DocumentSearchInterface:
         return PostgresDocumentSearch()
     elif provider_type == DocumentSearchProvider.ELASTICSEARCH:
         return ElasticsearchDocumentSearch(settings.elasticsearch_url)
+    elif provider_type == DocumentSearchProvider.TURBOPUFFER:
+        return TurbopufferDocumentSearch(api_key=settings.turbopuffer_api_key)
     else:
         # Default to postgres if unknown provider
         return PostgresDocumentSearch()

--- a/backend/packages/documents/providers/document_search/keyword_search_factory.py
+++ b/backend/packages/documents/providers/document_search/keyword_search_factory.py
@@ -8,6 +8,9 @@ from packages.documents.providers.document_search.keyword_search_interface impor
 from packages.documents.providers.document_search.elasticsearch_keyword_search import (
     ElasticsearchKeywordSearch,
 )
+from packages.documents.providers.document_search.turbopuffer_keyword_search import (
+    TurbopufferKeywordSearch,
+)
 from packages.documents.providers.document_search.types import KeywordSearchProvider
 from common.core.config import settings
 
@@ -20,7 +23,7 @@ def get_keyword_search_provider(
     Get keyword search provider instance.
 
     Args:
-        provider_type: Type of provider ('elasticsearch', 'postgres').
+        provider_type: Type of provider ('elasticsearch', 'postgres', 'turbopuffer').
                       If None, defaults to elasticsearch.
         elasticsearch_url: Elasticsearch URL (if using elasticsearch provider)
 
@@ -41,8 +44,9 @@ def get_keyword_search_provider(
                 elasticsearch_url if elasticsearch_url else settings.elasticsearch_url
             )
             return ElasticsearchKeywordSearch(elasticsearch_url=es_url)
+        case KeywordSearchProvider.TURBOPUFFER:
+            return TurbopufferKeywordSearch(api_key=settings.turbopuffer_api_key)
         case KeywordSearchProvider.POSTGRES:
-            # TODO: Implement PostgresKeywordSearch when needed
             raise NotImplementedError("Postgres keyword search not yet implemented")
         case _:
             raise ValueError(f"Unknown keyword search provider type: {provider_type}")

--- a/backend/packages/documents/providers/document_search/turbopuffer_document_search.py
+++ b/backend/packages/documents/providers/document_search/turbopuffer_document_search.py
@@ -1,0 +1,405 @@
+"""Turbopuffer document search implementation (BM25 full-text search on documents)."""
+
+import asyncio
+from typing import List, Optional
+from datetime import datetime
+
+import turbopuffer
+
+from .interface import (
+    DocumentSearchInterface,
+    DocumentSearchResult,
+    DocumentSearchFilters,
+)
+from .types import ChunkSearchResult, ChunkSearchFilters, ChunkSearchHit
+from packages.documents.models.domain.document import DocumentModel
+from common.core.otel_axiom_exporter import get_logger, trace_span
+
+logger = get_logger(__name__)
+
+DOCUMENT_SCHEMA = {
+    "doc_id": {"type": "uint", "filterable": True},
+    "company_id": {"type": "uint", "filterable": True},
+    "filename": {
+        "type": "string",
+        "full_text_search": {"tokenizer": "unicode61", "stemming": False},
+    },
+    "content_type": {"type": "string", "filterable": True},
+    "extraction_status": {"type": "string", "filterable": True},
+    "file_size": {"type": "uint", "filterable": False},
+    "checksum": {"type": "string", "filterable": False},
+    "storage_key": {"type": "string", "filterable": False},
+    "extracted_content": {
+        "type": "string",
+        "full_text_search": {
+            "tokenizer": "unicode61",
+            "stemming": True,
+            "language": "english",
+        },
+    },
+    "created_at": {"type": "string", "filterable": True},
+    "updated_at": {"type": "string", "filterable": True},
+}
+
+CHUNKS_SCHEMA = {
+    "chunk_id": {"type": "string", "filterable": True},
+    "document_id": {"type": "uint", "filterable": True},
+    "company_id": {"type": "uint", "filterable": True},
+    "matrix_id": {"type": "uint", "filterable": True},
+    "entity_set_id": {"type": "uint", "filterable": True},
+    "content": {
+        "type": "string",
+        "full_text_search": {
+            "tokenizer": "unicode61",
+            "stemming": True,
+            "language": "english",
+        },
+    },
+}
+
+
+class TurbopufferDocumentSearch(DocumentSearchInterface):
+    """Turbopuffer-based document search implementation."""
+
+    def __init__(self, api_key: str, embedding_dim: int = 1536):
+        self.api_key = api_key
+        self.doc_namespace_prefix = "corpus_documents"
+        self.chunks_namespace_prefix = "corpus_chunks"
+        self.embedding_dim = embedding_dim
+
+    def _doc_ns(self, company_id: int = None) -> turbopuffer.Namespace:
+        name = f"{self.doc_namespace_prefix}_{company_id}" if company_id else self.doc_namespace_prefix
+        return turbopuffer.Namespace(name, api_key=self.api_key)
+
+    def _chunks_ns(self, company_id: int = None) -> turbopuffer.Namespace:
+        name = f"{self.chunks_namespace_prefix}_{company_id}" if company_id else self.chunks_namespace_prefix
+        return turbopuffer.Namespace(name, api_key=self.api_key)
+
+    def _row_to_document(self, row) -> DocumentModel:
+        """Convert a turbopuffer row to DocumentModel."""
+        attrs = row if isinstance(row, dict) else row.__dict__
+
+        def _parse_dt(val):
+            if not val:
+                return None
+            if isinstance(val, datetime):
+                return val
+            return datetime.fromisoformat(str(val).replace("Z", "+00:00"))
+
+        return DocumentModel(
+            id=attrs.get("doc_id", 0),
+            filename=attrs.get("filename", ""),
+            storage_key=attrs.get("storage_key", ""),
+            content_type=attrs.get("content_type"),
+            file_size=attrs.get("file_size"),
+            checksum=attrs.get("checksum", ""),
+            company_id=attrs.get("company_id", 0),
+            extraction_status=attrs.get("extraction_status", "pending"),
+            created_at=_parse_dt(attrs.get("created_at")) or datetime.utcnow(),
+            updated_at=_parse_dt(attrs.get("updated_at")) or datetime.utcnow(),
+        )
+
+    @trace_span
+    async def search_documents(
+        self,
+        query: Optional[str] = None,
+        filters: Optional[DocumentSearchFilters] = None,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> DocumentSearchResult:
+        """Search documents using Turbopuffer BM25."""
+        try:
+            company_id = filters.company_id if filters else None
+            ns = self._doc_ns(company_id)
+
+            filter_conditions = []
+            if filters:
+                filter_conditions.append(("company_id", "Eq", filters.company_id))
+                if filters.content_type:
+                    filter_conditions.append(("content_type", "Eq", filters.content_type))
+                if filters.extraction_status:
+                    filter_conditions.append(("extraction_status", "Eq", filters.extraction_status))
+
+            tpuf_filters = None
+            if len(filter_conditions) == 1:
+                tpuf_filters = filter_conditions[0]
+            elif len(filter_conditions) > 1:
+                tpuf_filters = ("And", filter_conditions)
+
+            fetch_count = skip + limit
+
+            if query:
+                rank_by = (
+                    "Sum",
+                    [
+                        ("Product", 3, ("filename", "BM25", query)),
+                        ("extracted_content", "BM25", query),
+                    ],
+                )
+                result = await asyncio.to_thread(
+                    ns.query,
+                    rank_by=rank_by,
+                    top_k=fetch_count,
+                    filters=tpuf_filters,
+                    include_attributes=True,
+                )
+            else:
+                result = await asyncio.to_thread(
+                    ns.query,
+                    rank_by=("created_at", "desc"),
+                    top_k=fetch_count,
+                    filters=tpuf_filters,
+                    include_attributes=True,
+                )
+
+            rows = result.rows[skip:] if result.rows else []
+            documents = [self._row_to_document(row) for row in rows[:limit]]
+            total_count = len(result.rows) if result.rows else 0
+            has_more = total_count > skip + limit
+
+            return DocumentSearchResult(
+                documents=documents, total_count=total_count, has_more=has_more
+            )
+
+        except Exception as e:
+            logger.error(f"Turbopuffer document search failed: {e}")
+            return DocumentSearchResult(documents=[], total_count=0, has_more=False)
+
+    @trace_span
+    async def list_documents(
+        self,
+        filters: Optional[DocumentSearchFilters] = None,
+        skip: int = 0,
+        limit: int = 100,
+    ) -> DocumentSearchResult:
+        """List all documents with optional filters."""
+        return await self.search_documents(
+            query=None, filters=filters, skip=skip, limit=limit
+        )
+
+    @trace_span
+    async def get_supported_filters(self) -> List[str]:
+        """Get list of supported filter types."""
+        return ["content_type", "extraction_status", "created_after", "created_before"]
+
+    @trace_span
+    async def health_check(self) -> bool:
+        """Check if Turbopuffer is available."""
+        try:
+            namespaces = await asyncio.to_thread(turbopuffer.namespaces)
+            return True
+        except Exception as e:
+            logger.error(f"Turbopuffer health check failed: {e}")
+            return False
+
+    async def index_document(
+        self, document: DocumentModel, extracted_content: str = None
+    ) -> bool:
+        """Index a document in Turbopuffer."""
+        try:
+            ns = self._doc_ns(document.company_id)
+            row = {
+                "id": str(document.id),
+                "doc_id": document.id,
+                "company_id": document.company_id,
+                "filename": document.filename,
+                "content_type": document.content_type or "",
+                "extraction_status": str(document.extraction_status),
+                "file_size": document.file_size or 0,
+                "checksum": document.checksum,
+                "storage_key": document.storage_key,
+                "created_at": document.created_at.isoformat() if document.created_at else "",
+                "updated_at": document.updated_at.isoformat() if document.updated_at else "",
+            }
+            if extracted_content:
+                row["extracted_content"] = extracted_content
+
+            await asyncio.to_thread(
+                ns.write,
+                upsert_rows=[row],
+                distance_metric="cosine_distance",
+                schema=DOCUMENT_SCHEMA,
+            )
+            logger.info(f"Indexed document {document.id} in Turbopuffer")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to index document {document.id}: {e}")
+            return False
+
+    async def delete_document_from_index(self, document_id: int) -> bool:
+        """Delete a document from Turbopuffer."""
+        try:
+            ns = self._doc_ns()
+            await asyncio.to_thread(ns.write, deletes=[str(document_id)])
+            logger.info(f"Deleted document {document_id} from Turbopuffer")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to delete document {document_id}: {e}")
+            return False
+
+    async def index_chunk(
+        self,
+        chunk_id: str,
+        document_id: int,
+        company_id: int,
+        content: str,
+        metadata: dict,
+        embedding: Optional[List[float]] = None,
+    ) -> bool:
+        """Index a single chunk with optional vector embedding."""
+        try:
+            ns = self._chunks_ns(company_id)
+            doc_id = f"{document_id}_{chunk_id}"
+            row = {
+                "id": doc_id,
+                "chunk_id": chunk_id,
+                "document_id": document_id,
+                "company_id": company_id,
+                "matrix_id": metadata.get("matrix_id"),
+                "entity_set_id": metadata.get("entity_set_id"),
+                "content": content,
+            }
+            if embedding:
+                row["vector"] = embedding
+
+            await asyncio.to_thread(
+                ns.write,
+                upsert_rows=[row],
+                distance_metric="cosine_distance",
+                schema=CHUNKS_SCHEMA,
+            )
+            logger.debug(f"Indexed chunk {chunk_id} for document {document_id}")
+            return True
+        except Exception as e:
+            logger.error(f"Error indexing chunk {chunk_id}: {e}")
+            return False
+
+    async def index_chunks_bulk(self, chunks: List[dict]) -> bool:
+        """Bulk index multiple chunks."""
+        try:
+            by_company: dict[int, list] = {}
+            for chunk in chunks:
+                cid = chunk["company_id"]
+                by_company.setdefault(cid, []).append(chunk)
+
+            for company_id, company_chunks in by_company.items():
+                ns = self._chunks_ns(company_id)
+                rows = []
+                for chunk in company_chunks:
+                    doc_id = f"{chunk['document_id']}_{chunk['chunk_id']}"
+                    row = {
+                        "id": doc_id,
+                        "chunk_id": chunk["chunk_id"],
+                        "document_id": chunk["document_id"],
+                        "company_id": chunk["company_id"],
+                        "matrix_id": chunk["metadata"].get("matrix_id"),
+                        "entity_set_id": chunk["metadata"].get("entity_set_id"),
+                        "content": chunk["content"],
+                    }
+                    if chunk.get("embedding"):
+                        row["vector"] = chunk["embedding"]
+                    rows.append(row)
+
+                await asyncio.to_thread(
+                    ns.write,
+                    upsert_rows=rows,
+                    distance_metric="cosine_distance",
+                    schema=CHUNKS_SCHEMA,
+                )
+
+            logger.info(f"Bulk indexed {len(chunks)} chunks")
+            return True
+        except Exception as e:
+            logger.error(f"Error bulk indexing chunks: {e}")
+            return False
+
+    async def search_chunks(
+        self,
+        query: str,
+        filters: ChunkSearchFilters,
+        skip: int = 0,
+        limit: int = 10,
+    ) -> ChunkSearchResult:
+        """Hybrid search chunks using BM25 + vector if available."""
+        try:
+            ns = self._chunks_ns(filters.company_id)
+
+            filter_conditions = [("company_id", "Eq", filters.company_id)]
+            if filters.document_ids:
+                filter_conditions.append(("document_id", "In", filters.document_ids))
+            if filters.matrix_id:
+                filter_conditions.append(("matrix_id", "Eq", filters.matrix_id))
+            if filters.entity_set_id:
+                filter_conditions.append(("entity_set_id", "Eq", filters.entity_set_id))
+
+            tpuf_filters = filter_conditions[0] if len(filter_conditions) == 1 else ("And", filter_conditions)
+            fetch_count = skip + limit
+
+            if filters.query_vector:
+                rank_by = (
+                    "Sum",
+                    [
+                        ("content", "BM25", query),
+                        ("vector", "ANN", filters.query_vector),
+                    ],
+                )
+            else:
+                rank_by = ("content", "BM25", query)
+
+            result = await asyncio.to_thread(
+                ns.query,
+                rank_by=rank_by,
+                top_k=fetch_count,
+                filters=tpuf_filters,
+                include_attributes=True,
+            )
+
+            rows = result.rows[skip:] if result.rows else []
+            chunks = []
+            for row in rows[:limit]:
+                attrs = row if isinstance(row, dict) else row.__dict__
+                content = attrs.get("content", "")
+
+                highlights = []
+                query_lower = query.lower()
+                content_lower = content.lower()
+                idx = content_lower.find(query_lower)
+                if idx != -1:
+                    start = max(0, idx - 75)
+                    end = min(len(content), idx + len(query) + 75)
+                    highlights.append(f"...{content[start:end]}...")
+
+                chunks.append(
+                    ChunkSearchHit(
+                        chunk_id=attrs.get("chunk_id", ""),
+                        document_id=attrs.get("document_id", 0),
+                        company_id=attrs.get("company_id", 0),
+                        content=content,
+                        metadata={},
+                        score=attrs.get("$dist", 0.0),
+                        highlights=highlights,
+                    )
+                )
+
+            total_count = len(result.rows) if result.rows else 0
+            has_more = total_count > skip + limit
+
+            return ChunkSearchResult(
+                chunks=chunks, total_count=total_count, has_more=has_more
+            )
+
+        except Exception as e:
+            logger.error(f"Error searching chunks: {e}")
+            return ChunkSearchResult(chunks=[], total_count=0, has_more=False)
+
+    async def delete_chunk_from_index(self, chunk_id: str, document_id: int) -> bool:
+        """Remove a chunk from the search index."""
+        try:
+            doc_id = f"{document_id}_{chunk_id}"
+            ns = self._chunks_ns()
+            await asyncio.to_thread(ns.write, deletes=[doc_id])
+            logger.debug(f"Deleted chunk {chunk_id} from index")
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting chunk {chunk_id}: {e}")
+            return False

--- a/backend/packages/documents/providers/document_search/turbopuffer_keyword_search.py
+++ b/backend/packages/documents/providers/document_search/turbopuffer_keyword_search.py
@@ -1,0 +1,206 @@
+"""Turbopuffer keyword search implementation (BM25 full-text search)."""
+
+import asyncio
+from typing import List
+
+import turbopuffer
+
+from packages.documents.providers.document_search.keyword_search_interface import (
+    KeywordSearchInterface,
+)
+from packages.documents.providers.document_search.types import (
+    ChunkSearchResult,
+    ChunkSearchFilters,
+    ChunkSearchHit,
+)
+from common.core.otel_axiom_exporter import get_logger, trace_span
+
+logger = get_logger(__name__)
+
+SCHEMA = {
+    "chunk_id": {"type": "string", "filterable": True},
+    "document_id": {"type": "uint", "filterable": True},
+    "company_id": {"type": "uint", "filterable": True},
+    "matrix_id": {"type": "uint", "filterable": True},
+    "entity_set_id": {"type": "uint", "filterable": True},
+    "content": {
+        "type": "string",
+        "full_text_search": {
+            "tokenizer": "unicode61",
+            "stemming": True,
+            "language": "english",
+        },
+    },
+}
+
+
+class TurbopufferKeywordSearch(KeywordSearchInterface):
+    """Turbopuffer-based keyword search using BM25."""
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.namespace_prefix = "corpus_chunks_keyword"
+
+    def _ns(self, company_id: int = None) -> turbopuffer.Namespace:
+        """Get a turbopuffer namespace, optionally scoped to a company."""
+        name = f"{self.namespace_prefix}_{company_id}" if company_id else self.namespace_prefix
+        return turbopuffer.Namespace(name, api_key=self.api_key)
+
+    def _build_filters(self, filters: ChunkSearchFilters):
+        """Build turbopuffer filter tuple from ChunkSearchFilters."""
+        conditions = [("company_id", "Eq", filters.company_id)]
+
+        if filters.document_ids:
+            conditions.append(("document_id", "In", filters.document_ids))
+        if filters.matrix_id:
+            conditions.append(("matrix_id", "Eq", filters.matrix_id))
+        if filters.entity_set_id:
+            conditions.append(("entity_set_id", "Eq", filters.entity_set_id))
+
+        if len(conditions) == 1:
+            return conditions[0]
+        return ("And", conditions)
+
+    async def index_chunk(
+        self,
+        chunk_id: str,
+        document_id: int,
+        company_id: int,
+        content: str,
+        metadata: dict,
+    ) -> bool:
+        """Index a chunk for keyword search."""
+        try:
+            ns = self._ns(company_id)
+            doc_id = f"{document_id}_{chunk_id}"
+
+            await asyncio.to_thread(
+                ns.write,
+                upsert_rows=[
+                    {
+                        "id": doc_id,
+                        "chunk_id": chunk_id,
+                        "document_id": document_id,
+                        "company_id": company_id,
+                        "matrix_id": metadata.get("matrix_id"),
+                        "entity_set_id": metadata.get("entity_set_id"),
+                        "content": content,
+                    }
+                ],
+                distance_metric="cosine_distance",
+                schema=SCHEMA,
+            )
+            logger.debug(f"Indexed chunk {chunk_id} for keyword search")
+            return True
+        except Exception as e:
+            logger.error(f"Error indexing chunk {chunk_id} for keyword search: {e}")
+            return False
+
+    async def index_chunks_bulk(self, chunks: List[dict]) -> bool:
+        """Bulk index chunks for keyword search."""
+        try:
+            by_company: dict[int, list] = {}
+            for chunk in chunks:
+                cid = chunk["company_id"]
+                by_company.setdefault(cid, []).append(chunk)
+
+            for company_id, company_chunks in by_company.items():
+                ns = self._ns(company_id)
+                rows = []
+                for chunk in company_chunks:
+                    doc_id = f"{chunk['document_id']}_{chunk['chunk_id']}"
+                    rows.append(
+                        {
+                            "id": doc_id,
+                            "chunk_id": chunk["chunk_id"],
+                            "document_id": chunk["document_id"],
+                            "company_id": chunk["company_id"],
+                            "matrix_id": chunk["metadata"].get("matrix_id"),
+                            "entity_set_id": chunk["metadata"].get("entity_set_id"),
+                            "content": chunk["content"],
+                        }
+                    )
+                await asyncio.to_thread(
+                    ns.write,
+                    upsert_rows=rows,
+                    distance_metric="cosine_distance",
+                    schema=SCHEMA,
+                )
+
+            logger.info(f"Bulk indexed {len(chunks)} chunks for keyword search")
+            return True
+        except Exception as e:
+            logger.error(f"Error bulk indexing chunks for keyword search: {e}")
+            return False
+
+    @trace_span
+    async def keyword_search_chunks(
+        self,
+        query: str,
+        filters: ChunkSearchFilters,
+        skip: int = 0,
+        limit: int = 10,
+    ) -> ChunkSearchResult:
+        """Search chunks using BM25 keyword matching."""
+        try:
+            ns = self._ns(filters.company_id)
+            tpuf_filters = self._build_filters(filters)
+            fetch_count = skip + limit
+
+            result = await asyncio.to_thread(
+                ns.query,
+                rank_by=("content", "BM25", query),
+                top_k=fetch_count,
+                filters=tpuf_filters,
+                include_attributes=True,
+            )
+
+            rows = result.rows[skip:] if result.rows else []
+            chunks = []
+            for row in rows[:limit]:
+                attrs = row if isinstance(row, dict) else row.__dict__
+                content = attrs.get("content", "")
+
+                highlights = []
+                query_lower = query.lower()
+                content_lower = content.lower()
+                idx = content_lower.find(query_lower)
+                if idx != -1:
+                    start = max(0, idx - 75)
+                    end = min(len(content), idx + len(query) + 75)
+                    highlights.append(f"...{content[start:end]}...")
+
+                chunks.append(
+                    ChunkSearchHit(
+                        chunk_id=attrs.get("chunk_id", ""),
+                        document_id=attrs.get("document_id", 0),
+                        company_id=attrs.get("company_id", 0),
+                        content="",  # Content fetched separately from S3
+                        metadata={},
+                        score=attrs.get("$dist", 0.0),
+                        highlights=highlights,
+                    )
+                )
+
+            total_count = len(result.rows) if result.rows else 0
+            has_more = total_count > skip + limit
+
+            return ChunkSearchResult(
+                chunks=chunks, total_count=total_count, has_more=has_more
+            )
+
+        except Exception as e:
+            logger.error(f"Error in keyword search: {e}")
+            return ChunkSearchResult(chunks=[], total_count=0, has_more=False)
+
+    async def delete_chunk_from_index(self, chunk_id: str, document_id: int) -> bool:
+        """Remove chunk from keyword search index."""
+        try:
+            doc_id = f"{document_id}_{chunk_id}"
+            ns = self._ns()
+            await asyncio.to_thread(ns.write, deletes=[doc_id])
+            logger.debug(f"Deleted chunk {chunk_id} from keyword index")
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting chunk {chunk_id} from keyword index: {e}")
+            return False

--- a/backend/packages/documents/providers/document_search/turbopuffer_vector_search.py
+++ b/backend/packages/documents/providers/document_search/turbopuffer_vector_search.py
@@ -1,0 +1,182 @@
+"""Turbopuffer vector search implementation (ANN with cosine similarity)."""
+
+import asyncio
+from typing import List
+
+import turbopuffer
+
+from packages.documents.providers.document_search.vector_search_interface import (
+    VectorSearchInterface,
+)
+from packages.documents.providers.document_search.types import (
+    ChunkSearchResult,
+    ChunkSearchFilters,
+    ChunkSearchHit,
+)
+from common.core.otel_axiom_exporter import get_logger, trace_span
+
+logger = get_logger(__name__)
+
+
+class TurbopufferVectorSearch(VectorSearchInterface):
+    """Turbopuffer-based vector search using ANN."""
+
+    def __init__(self, api_key: str, embedding_dim: int = 1536):
+        self.api_key = api_key
+        self.namespace_prefix = "corpus_vectors"
+        self.embedding_dim = embedding_dim
+
+    def _ns(self, company_id: int = None) -> turbopuffer.Namespace:
+        """Get a turbopuffer namespace, optionally scoped to a company."""
+        name = f"{self.namespace_prefix}_{company_id}" if company_id else self.namespace_prefix
+        return turbopuffer.Namespace(name, api_key=self.api_key)
+
+    def _build_filters(self, filters: ChunkSearchFilters):
+        """Build turbopuffer filter tuple from ChunkSearchFilters."""
+        conditions = [("company_id", "Eq", filters.company_id)]
+
+        if filters.document_ids:
+            conditions.append(("document_id", "In", filters.document_ids))
+        if filters.matrix_id:
+            conditions.append(("matrix_id", "Eq", filters.matrix_id))
+        if filters.entity_set_id:
+            conditions.append(("entity_set_id", "Eq", filters.entity_set_id))
+
+        if len(conditions) == 1:
+            return conditions[0]
+        return ("And", conditions)
+
+    async def index_chunk_embedding(
+        self,
+        chunk_id: str,
+        document_id: int,
+        company_id: int,
+        embedding: List[float],
+        metadata: dict,
+    ) -> bool:
+        """Index a chunk embedding for vector search."""
+        try:
+            ns = self._ns(company_id)
+            doc_id = f"{document_id}_{chunk_id}"
+
+            await asyncio.to_thread(
+                ns.write,
+                upsert_rows=[
+                    {
+                        "id": doc_id,
+                        "vector": embedding,
+                        "chunk_id": chunk_id,
+                        "document_id": document_id,
+                        "company_id": company_id,
+                        "matrix_id": metadata.get("matrix_id"),
+                        "entity_set_id": metadata.get("entity_set_id"),
+                    }
+                ],
+                distance_metric="cosine_distance",
+            )
+            logger.debug(f"Indexed embedding for chunk {chunk_id}")
+            return True
+        except Exception as e:
+            logger.error(f"Error indexing embedding for chunk {chunk_id}: {e}")
+            return False
+
+    async def index_embeddings_bulk(self, embeddings: List[dict]) -> bool:
+        """Bulk index chunk embeddings."""
+        try:
+            by_company: dict[int, list] = {}
+            for emb in embeddings:
+                cid = emb["company_id"]
+                by_company.setdefault(cid, []).append(emb)
+
+            for company_id, embs in by_company.items():
+                ns = self._ns(company_id)
+                rows = []
+                for emb in embs:
+                    doc_id = f"{emb['document_id']}_{emb['chunk_id']}"
+                    rows.append(
+                        {
+                            "id": doc_id,
+                            "vector": emb["embedding"],
+                            "chunk_id": emb["chunk_id"],
+                            "document_id": emb["document_id"],
+                            "company_id": emb["company_id"],
+                            "matrix_id": emb["metadata"].get("matrix_id"),
+                            "entity_set_id": emb["metadata"].get("entity_set_id"),
+                        }
+                    )
+                await asyncio.to_thread(
+                    ns.write,
+                    upsert_rows=rows,
+                    distance_metric="cosine_distance",
+                )
+
+            logger.info(f"Bulk indexed {len(embeddings)} chunk embeddings")
+            return True
+        except Exception as e:
+            logger.error(f"Error bulk indexing embeddings: {e}")
+            return False
+
+    @trace_span
+    async def vector_search_chunks(
+        self,
+        query_vector: List[float],
+        filters: ChunkSearchFilters,
+        skip: int = 0,
+        limit: int = 10,
+    ) -> ChunkSearchResult:
+        """Search chunks using vector similarity (ANN)."""
+        try:
+            ns = self._ns(filters.company_id)
+            tpuf_filters = self._build_filters(filters)
+            fetch_count = skip + limit
+
+            result = await asyncio.to_thread(
+                ns.query,
+                rank_by=("vector", "ANN", query_vector),
+                top_k=fetch_count,
+                filters=tpuf_filters,
+                include_attributes=True,
+            )
+
+            rows = result.rows[skip:] if result.rows else []
+            chunks = []
+            for row in rows[:limit]:
+                attrs = row if isinstance(row, dict) else row.__dict__
+                chunks.append(
+                    ChunkSearchHit(
+                        chunk_id=attrs.get("chunk_id", ""),
+                        document_id=attrs.get("document_id", 0),
+                        company_id=attrs.get("company_id", 0),
+                        content="",  # Content fetched separately from S3
+                        metadata={},
+                        score=attrs.get("$dist", 0.0),
+                        highlights=[],
+                    )
+                )
+
+            total_count = len(result.rows) if result.rows else 0
+            has_more = total_count > skip + limit
+
+            return ChunkSearchResult(
+                chunks=chunks, total_count=total_count, has_more=has_more
+            )
+
+        except Exception as e:
+            logger.error(f"Error in vector search: {e}")
+            return ChunkSearchResult(chunks=[], total_count=0, has_more=False)
+
+    async def delete_chunk_embedding(self, chunk_id: str, document_id: int) -> bool:
+        """Remove chunk embedding from vector search index."""
+        try:
+            doc_id = f"{document_id}_{chunk_id}"
+            ns = self._ns()
+            await asyncio.to_thread(ns.write, deletes=[doc_id])
+            logger.debug(f"Deleted embedding for chunk {chunk_id}")
+            return True
+        except Exception as e:
+            logger.error(f"Error deleting embedding for chunk {chunk_id}: {e}")
+            return False
+
+    def get_embedding_dimension(self) -> int:
+        """Get expected embedding dimension."""
+        return self.embedding_dim

--- a/backend/packages/documents/providers/document_search/types.py
+++ b/backend/packages/documents/providers/document_search/types.py
@@ -7,6 +7,7 @@ class DocumentSearchProvider(StrEnum):
 
     POSTGRES = "postgres"
     ELASTICSEARCH = "elasticsearch"
+    TURBOPUFFER = "turbopuffer"
 
 
 class KeywordSearchProvider(StrEnum):
@@ -14,12 +15,14 @@ class KeywordSearchProvider(StrEnum):
 
     ELASTICSEARCH = "elasticsearch"
     POSTGRES = "postgres"
+    TURBOPUFFER = "turbopuffer"
 
 
 class VectorSearchProvider(StrEnum):
     """Vector search provider types."""
 
     ELASTICSEARCH = "elasticsearch"
+    TURBOPUFFER = "turbopuffer"
 
 
 class ChunkSearchHit:

--- a/backend/packages/documents/providers/document_search/vector_search_factory.py
+++ b/backend/packages/documents/providers/document_search/vector_search_factory.py
@@ -8,6 +8,9 @@ from packages.documents.providers.document_search.vector_search_interface import
 from packages.documents.providers.document_search.elasticsearch_vector_search import (
     ElasticsearchVectorSearch,
 )
+from packages.documents.providers.document_search.turbopuffer_vector_search import (
+    TurbopufferVectorSearch,
+)
 from packages.documents.providers.document_search.types import VectorSearchProvider
 from common.core.config import settings
 
@@ -21,7 +24,7 @@ def get_vector_search_provider(
     Get vector search provider instance.
 
     Args:
-        provider_type: Type of provider ('elasticsearch').
+        provider_type: Type of provider ('elasticsearch', 'turbopuffer').
                       If None, defaults to elasticsearch.
         elasticsearch_url: Elasticsearch URL (if using elasticsearch provider)
         embedding_dim: Embedding dimension size
@@ -44,6 +47,10 @@ def get_vector_search_provider(
             )
             return ElasticsearchVectorSearch(
                 elasticsearch_url=es_url, embedding_dim=embedding_dim
+            )
+        case VectorSearchProvider.TURBOPUFFER:
+            return TurbopufferVectorSearch(
+                api_key=settings.turbopuffer_api_key, embedding_dim=embedding_dim
             )
         case _:
             raise ValueError(f"Unknown vector search provider type: {provider_type}")

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -319,6 +319,19 @@ typing-extensions = ">=4.12"
 tz = ["tzdata"]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"},
+    {file = "annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4"},
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
@@ -2100,6 +2113,25 @@ grpcio = ">=1.71.2"
 protobuf = ">=5.26.1,<6.0dev"
 
 [[package]]
+name = "grpclib"
+version = "0.4.7"
+description = "Pure-Python gRPC implementation for asyncio"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "grpclib-0.4.7.tar.gz", hash = "sha256:2988ef57c02b22b7a2e8e961792c41ccf97efc2ace91ae7a5b0de03c363823c3"},
+]
+
+[package.dependencies]
+h2 = ">=3.1.0,<5"
+multidict = "*"
+
+[package.extras]
+protobuf = ["protobuf (>=3.20.0)"]
+
+[[package]]
 name = "gunicorn"
 version = "23.0.0"
 description = "WSGI HTTP Server for UNIX"
@@ -2395,6 +2427,19 @@ markers = "python_version >= \"3.12\" or python_version == \"3.11\""
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
+]
+
+[[package]]
+name = "iso8601"
+version = "2.1.0"
+description = "Simple module to parse ISO 8601 dates"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "iso8601-2.1.0-py3-none-any.whl", hash = "sha256:aac4145c4dcb66ad8b648a02830f5e2ff6c24af20f4f482689be402db2429242"},
+    {file = "iso8601-2.1.0.tar.gz", hash = "sha256:6b1d3829ee8921c4301998c909f7829fa9ed3cbdac0d3b16af2d743aed1ba8df"},
 ]
 
 [[package]]
@@ -2966,6 +3011,31 @@ docs = ["mdx_gh_links (>=0.2)", "mkdocs (>=1.6)", "mkdocs-gen-files", "mkdocs-li
 testing = ["coverage", "pyyaml"]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147"},
+    {file = "markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "markdown-it-pyrs", "mistletoe (>=1.0,<2.0)", "mistune (>=3.0,<4.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins (>=0.5.0)"]
+profiling = ["gprof2dot"]
+rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "requests"]
+
+[[package]]
 name = "markdownify"
 version = "1.2.2"
 description = "Convert HTML to markdown."
@@ -3171,6 +3241,47 @@ uvicorn = {version = ">=0.31.1", markers = "sys_platform != \"emscripten\""}
 cli = ["python-dotenv (>=1.0.0)", "typer (>=0.16.0)"]
 rich = ["rich (>=13.9.4)"]
 ws = ["websockets (>=15.0.1)"]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+
+[[package]]
+name = "modal"
+version = "0.74.62"
+description = "Python client library for Modal"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "modal-0.74.62-py3-none-any.whl", hash = "sha256:ca9a5af4ca414772ffe9b6154da873e489b72dcc7b628cc90f6d5c761a22b810"},
+    {file = "modal-0.74.62.tar.gz", hash = "sha256:534ff054ba6a6c36574ca01fcf04698d9274ba84531ab3130b9180a5782b1f86"},
+]
+
+[package.dependencies]
+aiohttp = "*"
+certifi = "*"
+click = ">=8.1.0"
+grpclib = "0.4.7"
+protobuf = ">=3.19,<4.24.0 || >4.24.0,<7.0"
+rich = ">=12.0.0"
+synchronicity = ">=0.9.12,<0.10.0"
+toml = "*"
+typer = ">=0.9"
+types-certifi = "*"
+types-toml = "*"
+typing_extensions = ">=4.6,<5.0"
+watchfiles = "*"
 
 [[package]]
 name = "mpmath"
@@ -4905,7 +5016,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version >= \"3.12\" or python_version == \"3.11\""
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
@@ -5551,6 +5662,26 @@ files = [
 decorator = ">=3.4.2"
 
 [[package]]
+name = "rich"
+version = "14.3.2"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.8.0"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69"},
+    {file = "rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 description = "Python bindings to Rust's persistent data structures (rpds)"
@@ -5778,6 +5909,39 @@ doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-
 enabler = ["pytest-enabler (>=2.2)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
 type = ["importlib_metadata (>=7.0.2)", "jaraco.develop (>=7.21)", "mypy (==1.14.*)", "pytest-mypy"]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
+name = "sigtools"
+version = "4.0.1"
+description = "Utilities for working with inspect.Signature objects."
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "sigtools-4.0.1-py2.py3-none-any.whl", hash = "sha256:d216b4cf920bbab0fce636ddc429ed8463a5b533d9e1492acb45a2a1bc36ac6c"},
+    {file = "sigtools-4.0.1.tar.gz", hash = "sha256:4b8e135a9cd4d2ea00da670c093372d74e672ba3abb87f4c98d8e73dea54445c"},
+]
+
+[package.dependencies]
+attrs = "*"
+
+[package.extras]
+test = ["coverage", "mock", "repeated-test (>=2.2.1)", "sphinx"]
+tests = ["coverage", "mock", "repeated-test (>=2.2.1)", "sphinx"]
 
 [[package]]
 name = "six"
@@ -6008,6 +6172,23 @@ mpmath = ">=1.1.0,<1.4"
 dev = ["hypothesis (>=6.70.0)", "pytest (>=7.1.0)"]
 
 [[package]]
+name = "synchronicity"
+version = "0.9.16"
+description = "Export blocking and async library versions from a single async implementation"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "synchronicity-0.9.16-py3-none-any.whl", hash = "sha256:79dd3451c063a06489d466b0585808e1d5d257fc3c2304f5f733a142ef269e97"},
+    {file = "synchronicity-0.9.16.tar.gz", hash = "sha256:bc174b756d12330b1e6027f8293c3b944cf3684dec241af009cb7bb169a0072f"},
+]
+
+[package.dependencies]
+sigtools = ">=4.0.1"
+typing-extensions = ">=4.12.2"
+
+[[package]]
 name = "temporalio"
 version = "1.21.1"
 description = "Temporal.io Python SDK"
@@ -6128,6 +6309,19 @@ pg8000 = ">=1.10"
 testing = ["SQLAlchemy", "nose", "psycopg2"]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
@@ -6151,6 +6345,59 @@ slack = ["slack-sdk"]
 telegram = ["requests"]
 
 [[package]]
+name = "turbopuffer"
+version = "0.4.1"
+description = "Python Client for accessing the turbopuffer API"
+optional = false
+python-versions = "<4.0,>=3.9"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "turbopuffer-0.4.1-py3-none-any.whl", hash = "sha256:1b7cc7c5555d7759826a5d7915cbff03779d43e237e78271992a1b1d47494ee4"},
+    {file = "turbopuffer-0.4.1.tar.gz", hash = "sha256:7d6db581505d8cd0e8fa09fa11e6a8d5e28af217169de36684e776dc6893b3b7"},
+]
+
+[package.dependencies]
+iso8601 = ">=2.1.0,<3.0.0"
+requests = ">=2.31,<3.0"
+typing-extensions = ">=4.12.2,<5.0.0"
+
+[package.extras]
+fast = ["orjson (>=3.9)", "pybase64 (>=1.4.1)"]
+
+[[package]]
+name = "typer"
+version = "0.24.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "typer-0.24.0-py3-none-any.whl", hash = "sha256:5fc435a9c8356f6160ed6e85a6301fdd6e3d8b2851da502050d1f92c5e9eddc8"},
+    {file = "typer-0.24.0.tar.gz", hash = "sha256:f9373dc4eff901350694f519f783c29b6d7a110fc0dcc11b1d7e353b85ca6504"},
+]
+
+[package.dependencies]
+annotated-doc = ">=0.0.2"
+click = ">=8.2.1"
+rich = ">=12.3.0"
+shellingham = ">=1.3.0"
+
+[[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+description = "Typing stubs for certifi"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f"},
+    {file = "types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a"},
+]
+
+[[package]]
 name = "types-protobuf"
 version = "6.32.1.20251210"
 description = "Typing stubs for protobuf"
@@ -6161,6 +6408,19 @@ markers = "python_version >= \"3.12\" or python_version == \"3.11\""
 files = [
     {file = "types_protobuf-6.32.1.20251210-py3-none-any.whl", hash = "sha256:2641f78f3696822a048cfb8d0ff42ccd85c25f12f871fbebe86da63793692140"},
     {file = "types_protobuf-6.32.1.20251210.tar.gz", hash = "sha256:c698bb3f020274b1a2798ae09dc773728ce3f75209a35187bd11916ebfde6763"},
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20240310"
+description = "Typing stubs for toml"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+markers = "python_version >= \"3.12\" or python_version == \"3.11\""
+files = [
+    {file = "types-toml-0.10.8.20240310.tar.gz", hash = "sha256:3d41501302972436a6b8b239c850b26689657e25281b48ff0ec06345b8830331"},
+    {file = "types_toml-0.10.8.20240310-py3-none-any.whl", hash = "sha256:627b47775d25fa29977d9c70dc0cbab3f314f32c8d8d0c012f2ef5de7aaec05d"},
 ]
 
 [[package]]
@@ -6915,4 +7175,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "85da24f8d506b43d1fa61e0b0f6a5b5f940486a563479983b47986cccbeb15b4"
+content-hash = "08208dad5524dbfce72d0ae7aecdbffac71edd098ad34a22afe879cfc94a1893"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -72,6 +72,8 @@ qa = {path = "../libs/qa", develop = true}
 workflows = {path = "../libs/workflows", develop = true}
 ai-config = {path = "../libs/ai_config", develop = true}
 firebase-admin = ">=6.0.0,<7.0.0"
+turbopuffer = "^0.4.0"
+modal = "^0.74.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/backend/tests/unit/common/execution/executors/test_modal_executor.py
+++ b/backend/tests/unit/common/execution/executors/test_modal_executor.py
@@ -1,0 +1,126 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from common.execution.executors.modal_executor import ModalExecutor
+from common.execution.job_spec import JobSpec
+
+
+class TestModalExecutor:
+    """Tests for ModalExecutor with mocked Modal SDK."""
+
+    @pytest.fixture
+    def executor(self):
+        with patch(
+            "common.execution.executors.modal_executor.modal"
+        ) as mock_modal:
+            mock_app = MagicMock()
+            mock_modal.App.lookup.return_value = mock_app
+
+            executor = ModalExecutor()
+            executor._mock_modal = mock_modal
+            yield executor
+
+    @patch("common.execution.executors.modal_executor.settings")
+    def test_launch_job(self, mock_settings, executor):
+        mock_settings.workflow_agent_image_tag = "v1.2.3"
+
+        mock_sandbox = MagicMock()
+        mock_sandbox.object_id = "sb-123456"
+        executor._mock_modal.Sandbox.create.return_value = mock_sandbox
+
+        job_spec = JobSpec(
+            container_name="workflow-exec-123",
+            template_name="workflow_job.yaml.j2",
+            image_name="corpus/workflow-agent",
+            image_tag="latest",
+            env_vars={
+                "API_ENDPOINT": "http://test:8000",
+                "API_KEY": "sa_test_key",
+            },
+            template_vars={"timeout": 600},
+        )
+
+        result = executor.launch(job_spec)
+
+        assert result["mode"] == "modal"
+        assert result["sandbox_id"] == "sb-123456"
+        assert result["job_name"] == "workflow-exec-123"
+
+        executor._mock_modal.Sandbox.create.assert_called_once()
+        call_kwargs = executor._mock_modal.Sandbox.create.call_args[1]
+        assert call_kwargs["timeout"] == 600
+        assert call_kwargs["cpu"] == 1.0
+        assert call_kwargs["memory"] == 1024
+        assert call_kwargs["env"]["API_ENDPOINT"] == "http://test:8000"
+
+    def test_launch_job_default_timeout(self, executor):
+        mock_sandbox = MagicMock()
+        mock_sandbox.object_id = "sb-789"
+        executor._mock_modal.Sandbox.create.return_value = mock_sandbox
+
+        with patch("common.execution.executors.modal_executor.settings") as mock_settings:
+            mock_settings.workflow_agent_image_tag = "latest"
+
+            job_spec = JobSpec(
+                container_name="test-job",
+                template_name="agent_qa_job.yaml.j2",
+                image_name="corpus/agent-qa",
+                env_vars={},
+                template_vars={},  # No timeout specified
+            )
+
+            result = executor.launch(job_spec)
+
+            call_kwargs = executor._mock_modal.Sandbox.create.call_args[1]
+            assert call_kwargs["timeout"] == 900  # Default
+
+    def test_check_status_running(self, executor):
+        mock_sandbox = MagicMock()
+        mock_sandbox.poll.return_value = None
+        executor._mock_modal.Sandbox.from_id.return_value = mock_sandbox
+
+        result = executor.check_status({"sandbox_id": "sb-123"})
+
+        assert result["status"] == "running"
+
+    def test_check_status_completed(self, executor):
+        mock_sandbox = MagicMock()
+        mock_sandbox.poll.return_value = 0
+        executor._mock_modal.Sandbox.from_id.return_value = mock_sandbox
+
+        result = executor.check_status({"sandbox_id": "sb-123"})
+
+        assert result["status"] == "completed"
+        assert result["exit_code"] == 0
+
+    def test_check_status_failed(self, executor):
+        mock_sandbox = MagicMock()
+        mock_sandbox.poll.return_value = 1
+        executor._mock_modal.Sandbox.from_id.return_value = mock_sandbox
+
+        result = executor.check_status({"sandbox_id": "sb-123"})
+
+        assert result["status"] == "failed"
+        assert result["exit_code"] == 1
+
+    def test_check_status_not_found(self, executor):
+        executor._mock_modal.Sandbox.from_id.side_effect = Exception("Not found")
+
+        result = executor.check_status({"sandbox_id": "sb-missing"})
+
+        assert result["status"] == "failed"
+        assert "not found" in result["error"].lower()
+
+    def test_cleanup_success(self, executor):
+        mock_sandbox = MagicMock()
+        executor._mock_modal.Sandbox.from_id.return_value = mock_sandbox
+
+        executor.cleanup({"sandbox_id": "sb-123", "job_name": "test-job"})
+
+        mock_sandbox.terminate.assert_called_once()
+
+    def test_cleanup_already_terminated(self, executor):
+        executor._mock_modal.Sandbox.from_id.side_effect = Exception("Not found")
+
+        # Should not raise
+        executor.cleanup({"sandbox_id": "sb-missing", "job_name": "test-job"})

--- a/backend/tests/unit/packages/documents/providers/document_search/test_turbopuffer_document_search.py
+++ b/backend/tests/unit/packages/documents/providers/document_search/test_turbopuffer_document_search.py
@@ -1,0 +1,242 @@
+import pytest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from packages.documents.providers.document_search.turbopuffer_document_search import (
+    TurbopufferDocumentSearch,
+)
+from packages.documents.providers.document_search.interface import DocumentSearchFilters
+from packages.documents.providers.document_search.types import ChunkSearchFilters
+from packages.documents.models.domain.document import DocumentModel
+
+
+class TestTurbopufferDocumentSearch:
+    """Tests for TurbopufferDocumentSearch with mocked Turbopuffer client."""
+
+    @pytest.fixture
+    def mock_doc_ns(self):
+        ns = MagicMock()
+        ns.write = MagicMock()
+        ns.query = MagicMock()
+        return ns
+
+    @pytest.fixture
+    def mock_chunks_ns(self):
+        ns = MagicMock()
+        ns.write = MagicMock()
+        ns.query = MagicMock()
+        return ns
+
+    @pytest.fixture
+    def provider(self, mock_doc_ns, mock_chunks_ns):
+        with patch(
+            "packages.documents.providers.document_search.turbopuffer_document_search.turbopuffer"
+        ) as mock_tpuf:
+
+            def namespace_router(name, api_key=None):
+                if "documents" in name:
+                    return mock_doc_ns
+                return mock_chunks_ns
+
+            mock_tpuf.Namespace.side_effect = namespace_router
+
+            p = TurbopufferDocumentSearch(api_key="test-key")
+            yield p
+
+    @pytest.mark.asyncio
+    async def test_index_document(self, provider, mock_doc_ns):
+        mock_doc_ns.write.return_value = MagicMock(rows_affected=1)
+
+        doc = DocumentModel(
+            id=1,
+            filename="test.pdf",
+            storage_key="docs/test.pdf",
+            content_type="application/pdf",
+            file_size=1024,
+            checksum="abc123",
+            company_id=1,
+            created_at=datetime(2024, 1, 1),
+            updated_at=datetime(2024, 1, 1),
+        )
+
+        result = await provider.index_document(doc, extracted_content="Test content")
+
+        assert result is True
+        mock_doc_ns.write.assert_called_once()
+        row = mock_doc_ns.write.call_args[1]["upsert_rows"][0]
+        assert row["filename"] == "test.pdf"
+        assert row["extracted_content"] == "Test content"
+        assert row["doc_id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_index_document_failure(self, provider, mock_doc_ns):
+        mock_doc_ns.write.side_effect = Exception("API error")
+
+        doc = DocumentModel(
+            id=1,
+            filename="test.pdf",
+            storage_key="docs/test.pdf",
+            checksum="abc123",
+            company_id=1,
+            created_at=datetime(2024, 1, 1),
+            updated_at=datetime(2024, 1, 1),
+        )
+
+        result = await provider.index_document(doc)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_search_documents(self, provider, mock_doc_ns):
+        mock_row = SimpleNamespace(
+            doc_id=1,
+            filename="test.pdf",
+            storage_key="docs/test.pdf",
+            content_type="application/pdf",
+            file_size=1024,
+            checksum="abc123",
+            company_id=1,
+            extraction_status="completed",
+            created_at="2024-01-01T00:00:00",
+            updated_at="2024-01-01T00:00:00",
+            **{"$dist": 5.0},
+        )
+        mock_result = MagicMock()
+        mock_result.rows = [mock_row]
+        mock_doc_ns.query.return_value = mock_result
+
+        filters = DocumentSearchFilters(company_id=1)
+        result = await provider.search_documents(
+            query="test", filters=filters, skip=0, limit=10
+        )
+
+        assert len(result.documents) == 1
+        assert result.documents[0].filename == "test.pdf"
+
+    @pytest.mark.asyncio
+    async def test_search_documents_error(self, provider, mock_doc_ns):
+        mock_doc_ns.query.side_effect = Exception("API error")
+
+        filters = DocumentSearchFilters(company_id=1)
+        result = await provider.search_documents(query="test", filters=filters)
+
+        assert len(result.documents) == 0
+        assert result.total_count == 0
+
+    @pytest.mark.asyncio
+    async def test_list_documents(self, provider, mock_doc_ns):
+        mock_result = MagicMock()
+        mock_result.rows = []
+        mock_doc_ns.query.return_value = mock_result
+
+        filters = DocumentSearchFilters(company_id=1)
+        result = await provider.list_documents(filters=filters)
+
+        assert len(result.documents) == 0
+        mock_doc_ns.query.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_document_from_index(self, provider, mock_doc_ns):
+        mock_doc_ns.write.return_value = MagicMock(rows_affected=1)
+
+        result = await provider.delete_document_from_index(document_id=1)
+
+        assert result is True
+        mock_doc_ns.write.assert_called_once()
+        assert "1" in mock_doc_ns.write.call_args[1]["deletes"]
+
+    @pytest.mark.asyncio
+    async def test_index_chunk(self, provider, mock_chunks_ns):
+        mock_chunks_ns.write.return_value = MagicMock(rows_affected=1)
+
+        result = await provider.index_chunk(
+            chunk_id="chunk-1",
+            document_id=10,
+            company_id=1,
+            content="Chunk content here",
+            metadata={"matrix_id": 5},
+            embedding=[0.1] * 1536,
+        )
+
+        assert result is True
+        row = mock_chunks_ns.write.call_args[1]["upsert_rows"][0]
+        assert row["content"] == "Chunk content here"
+        assert row["vector"] == [0.1] * 1536
+
+    @pytest.mark.asyncio
+    async def test_index_chunks_bulk(self, provider, mock_chunks_ns):
+        mock_chunks_ns.write.return_value = MagicMock(rows_affected=2)
+
+        chunks = [
+            {
+                "chunk_id": "c1",
+                "document_id": 10,
+                "company_id": 1,
+                "content": "First",
+                "metadata": {},
+            },
+            {
+                "chunk_id": "c2",
+                "document_id": 10,
+                "company_id": 1,
+                "content": "Second",
+                "metadata": {},
+                "embedding": [0.2] * 1536,
+            },
+        ]
+
+        result = await provider.index_chunks_bulk(chunks)
+
+        assert result is True
+        rows = mock_chunks_ns.write.call_args[1]["upsert_rows"]
+        assert len(rows) == 2
+        # First chunk has no vector, second does
+        assert "vector" not in rows[0]
+        assert rows[1]["vector"] == [0.2] * 1536
+
+    @pytest.mark.asyncio
+    async def test_search_chunks_keyword_only(self, provider, mock_chunks_ns):
+        mock_result = MagicMock()
+        mock_result.rows = []
+        mock_chunks_ns.query.return_value = mock_result
+
+        filters = ChunkSearchFilters(company_id=1)
+        result = await provider.search_chunks(query="test", filters=filters)
+
+        assert len(result.chunks) == 0
+        call_kwargs = mock_chunks_ns.query.call_args[1]
+        # Without query_vector, should use BM25 only
+        rank_by = call_kwargs["rank_by"]
+        assert rank_by == ("content", "BM25", "test")
+
+    @pytest.mark.asyncio
+    async def test_search_chunks_hybrid(self, provider, mock_chunks_ns):
+        mock_result = MagicMock()
+        mock_result.rows = []
+        mock_chunks_ns.query.return_value = mock_result
+
+        filters = ChunkSearchFilters(company_id=1, query_vector=[0.1] * 1536)
+        result = await provider.search_chunks(query="test", filters=filters)
+
+        assert len(result.chunks) == 0
+        call_kwargs = mock_chunks_ns.query.call_args[1]
+        # With query_vector, should use Sum of BM25 + ANN
+        rank_by = call_kwargs["rank_by"]
+        assert rank_by[0] == "Sum"
+
+    @pytest.mark.asyncio
+    async def test_delete_chunk_from_index(self, provider, mock_chunks_ns):
+        mock_chunks_ns.write.return_value = MagicMock(rows_affected=1)
+
+        result = await provider.delete_chunk_from_index(
+            chunk_id="chunk-1", document_id=10
+        )
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_get_supported_filters(self, provider):
+        filters = await provider.get_supported_filters()
+        assert "content_type" in filters
+        assert "extraction_status" in filters

--- a/backend/tests/unit/packages/documents/providers/document_search/test_turbopuffer_keyword_search.py
+++ b/backend/tests/unit/packages/documents/providers/document_search/test_turbopuffer_keyword_search.py
@@ -1,0 +1,155 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from packages.documents.providers.document_search.turbopuffer_keyword_search import (
+    TurbopufferKeywordSearch,
+)
+from packages.documents.providers.document_search.types import ChunkSearchFilters
+
+
+class TestTurbopufferKeywordSearch:
+    """Tests for TurbopufferKeywordSearch with mocked Turbopuffer client."""
+
+    @pytest.fixture
+    def mock_ns(self):
+        ns = MagicMock()
+        ns.write = MagicMock()
+        ns.query = MagicMock()
+        return ns
+
+    @pytest.fixture
+    def provider(self, mock_ns):
+        with patch(
+            "packages.documents.providers.document_search.turbopuffer_keyword_search.turbopuffer"
+        ) as mock_tpuf:
+            mock_tpuf.Namespace.return_value = mock_ns
+
+            p = TurbopufferKeywordSearch(api_key="test-key")
+            yield p
+
+    @pytest.mark.asyncio
+    async def test_index_chunk(self, provider, mock_ns):
+        mock_ns.write.return_value = MagicMock(rows_affected=1)
+
+        result = await provider.index_chunk(
+            chunk_id="chunk-1",
+            document_id=10,
+            company_id=1,
+            content="This is test content for BM25 indexing.",
+            metadata={"matrix_id": 5},
+        )
+
+        assert result is True
+        mock_ns.write.assert_called_once()
+        row = mock_ns.write.call_args[1]["upsert_rows"][0]
+        assert row["content"] == "This is test content for BM25 indexing."
+        assert row["chunk_id"] == "chunk-1"
+
+    @pytest.mark.asyncio
+    async def test_index_chunk_failure(self, provider, mock_ns):
+        mock_ns.write.side_effect = Exception("API error")
+
+        result = await provider.index_chunk(
+            chunk_id="chunk-1",
+            document_id=10,
+            company_id=1,
+            content="content",
+            metadata={},
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_index_chunks_bulk(self, provider, mock_ns):
+        mock_ns.write.return_value = MagicMock(rows_affected=2)
+
+        chunks = [
+            {
+                "chunk_id": "chunk-1",
+                "document_id": 10,
+                "company_id": 1,
+                "content": "First chunk content",
+                "metadata": {"matrix_id": 5},
+            },
+            {
+                "chunk_id": "chunk-2",
+                "document_id": 10,
+                "company_id": 1,
+                "content": "Second chunk content",
+                "metadata": {"matrix_id": 5},
+            },
+        ]
+
+        result = await provider.index_chunks_bulk(chunks)
+
+        assert result is True
+        mock_ns.write.assert_called_once()
+        assert len(mock_ns.write.call_args[1]["upsert_rows"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_keyword_search_chunks(self, provider, mock_ns):
+        mock_row = SimpleNamespace(
+            chunk_id="chunk-1",
+            document_id=10,
+            company_id=1,
+            content="The quick brown fox jumps over the lazy dog",
+            **{"$dist": 5.2},
+        )
+        mock_result = MagicMock()
+        mock_result.rows = [mock_row]
+        mock_ns.query.return_value = mock_result
+
+        filters = ChunkSearchFilters(company_id=1, document_ids=[10])
+        result = await provider.keyword_search_chunks(
+            query="quick fox",
+            filters=filters,
+            skip=0,
+            limit=10,
+        )
+
+        assert len(result.chunks) == 1
+        assert result.chunks[0].chunk_id == "chunk-1"
+
+        mock_ns.query.assert_called_once()
+        call_kwargs = mock_ns.query.call_args[1]
+        assert call_kwargs["top_k"] == 10
+
+    @pytest.mark.asyncio
+    async def test_keyword_search_chunks_with_filters(self, provider, mock_ns):
+        mock_result = MagicMock()
+        mock_result.rows = []
+        mock_ns.query.return_value = mock_result
+
+        filters = ChunkSearchFilters(
+            company_id=1, document_ids=[10, 20], matrix_id=5, entity_set_id=3
+        )
+        await provider.keyword_search_chunks(query="test", filters=filters)
+
+        call_kwargs = mock_ns.query.call_args[1]
+        tpuf_filters = call_kwargs["filters"]
+        # Should be an And filter with 4 conditions
+        assert tpuf_filters[0] == "And"
+        assert len(tpuf_filters[1]) == 4
+
+    @pytest.mark.asyncio
+    async def test_keyword_search_chunks_error(self, provider, mock_ns):
+        mock_ns.query.side_effect = Exception("API error")
+
+        filters = ChunkSearchFilters(company_id=1)
+        result = await provider.keyword_search_chunks(query="test", filters=filters)
+
+        assert len(result.chunks) == 0
+        assert result.total_count == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_chunk_from_index(self, provider, mock_ns):
+        mock_ns.write.return_value = MagicMock(rows_affected=1)
+
+        result = await provider.delete_chunk_from_index(
+            chunk_id="chunk-1", document_id=10
+        )
+
+        assert result is True
+        mock_ns.write.assert_called_once()
+        assert "10_chunk-1" in mock_ns.write.call_args[1]["deletes"]

--- a/backend/tests/unit/packages/documents/providers/document_search/test_turbopuffer_vector_search.py
+++ b/backend/tests/unit/packages/documents/providers/document_search/test_turbopuffer_vector_search.py
@@ -1,0 +1,166 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from packages.documents.providers.document_search.turbopuffer_vector_search import (
+    TurbopufferVectorSearch,
+)
+from packages.documents.providers.document_search.types import ChunkSearchFilters
+
+
+class TestTurbopufferVectorSearch:
+    """Tests for TurbopufferVectorSearch with mocked Turbopuffer client."""
+
+    @pytest.fixture
+    def mock_ns(self):
+        ns = MagicMock()
+        ns.write = MagicMock()
+        ns.query = MagicMock()
+        return ns
+
+    @pytest.fixture
+    def provider(self, mock_ns):
+        with patch(
+            "packages.documents.providers.document_search.turbopuffer_vector_search.turbopuffer"
+        ) as mock_tpuf:
+            mock_tpuf.Namespace.return_value = mock_ns
+
+            p = TurbopufferVectorSearch(api_key="test-key", embedding_dim=1536)
+            yield p
+
+    @pytest.mark.asyncio
+    async def test_index_chunk_embedding(self, provider, mock_ns):
+        mock_ns.write.return_value = MagicMock(rows_affected=1)
+
+        result = await provider.index_chunk_embedding(
+            chunk_id="chunk-1",
+            document_id=10,
+            company_id=1,
+            embedding=[0.1] * 1536,
+            metadata={"matrix_id": 5, "entity_set_id": 3},
+        )
+
+        assert result is True
+        mock_ns.write.assert_called_once()
+        call_kwargs = mock_ns.write.call_args[1]
+        assert len(call_kwargs["upsert_rows"]) == 1
+        row = call_kwargs["upsert_rows"][0]
+        assert row["id"] == "10_chunk-1"
+        assert row["chunk_id"] == "chunk-1"
+        assert row["company_id"] == 1
+        assert call_kwargs["distance_metric"] == "cosine_distance"
+
+    @pytest.mark.asyncio
+    async def test_index_chunk_embedding_failure(self, provider, mock_ns):
+        mock_ns.write.side_effect = Exception("API error")
+
+        result = await provider.index_chunk_embedding(
+            chunk_id="chunk-1",
+            document_id=10,
+            company_id=1,
+            embedding=[0.1] * 1536,
+            metadata={},
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_index_embeddings_bulk(self, provider, mock_ns):
+        mock_ns.write.return_value = MagicMock(rows_affected=2)
+
+        embeddings = [
+            {
+                "chunk_id": "chunk-1",
+                "document_id": 10,
+                "company_id": 1,
+                "embedding": [0.1] * 1536,
+                "metadata": {"matrix_id": 5},
+            },
+            {
+                "chunk_id": "chunk-2",
+                "document_id": 10,
+                "company_id": 1,
+                "embedding": [0.2] * 1536,
+                "metadata": {"matrix_id": 5},
+            },
+        ]
+
+        result = await provider.index_embeddings_bulk(embeddings)
+
+        assert result is True
+        mock_ns.write.assert_called_once()
+        call_kwargs = mock_ns.write.call_args[1]
+        assert len(call_kwargs["upsert_rows"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_vector_search_chunks(self, provider, mock_ns):
+        mock_row = SimpleNamespace(
+            chunk_id="chunk-1",
+            document_id=10,
+            company_id=1,
+            **{"$dist": 0.95},
+        )
+        mock_result = MagicMock()
+        mock_result.rows = [mock_row]
+        mock_ns.query.return_value = mock_result
+
+        filters = ChunkSearchFilters(company_id=1, document_ids=[10])
+        result = await provider.vector_search_chunks(
+            query_vector=[0.1] * 1536,
+            filters=filters,
+            skip=0,
+            limit=10,
+        )
+
+        assert len(result.chunks) == 1
+        assert result.chunks[0].chunk_id == "chunk-1"
+        assert result.chunks[0].document_id == 10
+
+        mock_ns.query.assert_called_once()
+        call_kwargs = mock_ns.query.call_args[1]
+        assert call_kwargs["top_k"] == 10
+        assert call_kwargs["include_attributes"] is True
+
+    @pytest.mark.asyncio
+    async def test_vector_search_chunks_empty(self, provider, mock_ns):
+        mock_result = MagicMock()
+        mock_result.rows = []
+        mock_ns.query.return_value = mock_result
+
+        filters = ChunkSearchFilters(company_id=1)
+        result = await provider.vector_search_chunks(
+            query_vector=[0.1] * 1536,
+            filters=filters,
+        )
+
+        assert len(result.chunks) == 0
+        assert result.total_count == 0
+
+    @pytest.mark.asyncio
+    async def test_vector_search_chunks_error(self, provider, mock_ns):
+        mock_ns.query.side_effect = Exception("API error")
+
+        filters = ChunkSearchFilters(company_id=1)
+        result = await provider.vector_search_chunks(
+            query_vector=[0.1] * 1536,
+            filters=filters,
+        )
+
+        assert len(result.chunks) == 0
+        assert result.total_count == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_chunk_embedding(self, provider, mock_ns):
+        mock_ns.write.return_value = MagicMock(rows_affected=1)
+
+        result = await provider.delete_chunk_embedding(
+            chunk_id="chunk-1", document_id=10
+        )
+
+        assert result is True
+        mock_ns.write.assert_called_once()
+        call_kwargs = mock_ns.write.call_args[1]
+        assert "10_chunk-1" in call_kwargs["deletes"]
+
+    def test_get_embedding_dimension(self, provider):
+        assert provider.get_embedding_dimension() == 1536

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,7 @@ services:
     environment:
       # Docker-specific overrides
       - ENVIRONMENT=local
+      - STORAGE_PROVIDER=s3
       - DB_HOST=postgres
       - RABBITMQ_HOST=rabbitmq
       - REDIS_HOST=corpus-redis
@@ -233,6 +234,7 @@ services:
     environment:
       # Docker-specific overrides
       - ENVIRONMENT=local
+      - STORAGE_PROVIDER=s3
       - DB_HOST=postgres
       - RABBITMQ_HOST=rabbitmq
       - REDIS_HOST=corpus-redis
@@ -279,6 +281,7 @@ services:
     environment:
       # Docker-specific overrides
       - ENVIRONMENT=local
+      - STORAGE_PROVIDER=s3
       - DB_HOST=postgres
       - RABBITMQ_HOST=rabbitmq
       - REDIS_HOST=corpus-redis
@@ -326,6 +329,7 @@ services:
     environment:
       # Database Components
       - ENVIRONMENT=local
+      - STORAGE_PROVIDER=s3
       - DB_HOST=postgres
       - RABBITMQ_HOST=rabbitmq
       - REDIS_HOST=corpus-redis
@@ -370,6 +374,7 @@ services:
     environment:
       # Database Components
       - ENVIRONMENT=local
+      - STORAGE_PROVIDER=s3
       - DB_HOST=postgres
       - RABBITMQ_HOST=rabbitmq
       - REDIS_HOST=corpus-redis
@@ -414,6 +419,7 @@ services:
       - ./backend/.env
     environment:
       - ENVIRONMENT=local
+      - STORAGE_PROVIDER=s3
       - DB_HOST=postgres
       - RABBITMQ_HOST=rabbitmq
       - REDIS_HOST=corpus-redis
@@ -458,6 +464,7 @@ services:
     environment:
       # Database Components
       - ENVIRONMENT=local
+      - STORAGE_PROVIDER=s3
       - DB_HOST=postgres
       - RABBITMQ_HOST=rabbitmq
       - REDIS_HOST=corpus-redis
@@ -501,6 +508,7 @@ services:
       - ./backend/.env
     environment:
       - ENVIRONMENT=local
+      - STORAGE_PROVIDER=s3
       - DB_HOST=postgres
       - S3_ENDPOINT_URL=http://localstack:4566
       - AWS_ACCESS_KEY_ID=test
@@ -537,6 +545,7 @@ services:
       - ./backend/.env
     environment:
       - ENVIRONMENT=local
+      - STORAGE_PROVIDER=s3
       - DB_HOST=postgres
       - S3_ENDPOINT_URL=http://localstack:4566
       - AWS_ACCESS_KEY_ID=test

--- a/fly-deploy/agent.toml
+++ b/fly-deploy/agent.toml
@@ -1,0 +1,31 @@
+app = "corpus-agent"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/api/Dockerfile"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = "connections"
+    hard_limit = 500
+    soft_limit = 400
+
+[[http_service.checks]]
+  path = "/healthz"
+  interval = 30000
+  timeout = 5000
+  grace_period = "10s"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "1gb"

--- a/fly-deploy/api.toml
+++ b/fly-deploy/api.toml
@@ -1,0 +1,31 @@
+app = "corpus-api"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/api/Dockerfile"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 1
+
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 250
+    soft_limit = 200
+
+[[http_service.checks]]
+  path = "/healthz"
+  interval = 30000
+  timeout = 5000
+  grace_period = "10s"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/fly-deploy/worker-document-indexing.toml
+++ b/fly-deploy/worker-document-indexing.toml
@@ -1,0 +1,16 @@
+app = "corpus-worker-document-indexing"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/workers/Dockerfile"
+
+[processes]
+  worker = "python -m workers.run_document_indexing_worker"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/fly-deploy/worker-qa.toml
+++ b/fly-deploy/worker-qa.toml
@@ -1,0 +1,16 @@
+app = "corpus-worker-qa"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/workers/Dockerfile"
+
+[processes]
+  worker = "python -m workers.run_qa_worker"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/fly-deploy/worker-temporal-chunking.toml
+++ b/fly-deploy/worker-temporal-chunking.toml
@@ -1,0 +1,16 @@
+app = "corpus-temporal-chunking"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/workers/Dockerfile"
+
+[processes]
+  worker = "python -m workers.run_temporal_worker --queue document-chunking-queue"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/fly-deploy/worker-temporal-generic.toml
+++ b/fly-deploy/worker-temporal-generic.toml
@@ -1,0 +1,16 @@
+app = "corpus-temporal-generic"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/workers/Dockerfile"
+
+[processes]
+  worker = "python -m workers.run_temporal_worker --queue generic-extraction-queue"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/fly-deploy/worker-temporal-page.toml
+++ b/fly-deploy/worker-temporal-page.toml
@@ -1,0 +1,16 @@
+app = "corpus-temporal-page"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/workers/Dockerfile"
+
+[processes]
+  worker = "python -m workers.run_temporal_worker --queue page-conversion-queue"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/fly-deploy/worker-temporal-pdf.toml
+++ b/fly-deploy/worker-temporal-pdf.toml
@@ -1,0 +1,16 @@
+app = "corpus-temporal-pdf"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/workers/Dockerfile"
+
+[processes]
+  worker = "python -m workers.run_temporal_worker --queue pdf-processing-queue"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/fly-deploy/worker-temporal-qa.toml
+++ b/fly-deploy/worker-temporal-qa.toml
@@ -1,0 +1,16 @@
+app = "corpus-temporal-qa"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/workers/Dockerfile"
+
+[processes]
+  worker = "python -m workers.run_agent_qa_worker"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/fly-deploy/worker-temporal-routing.toml
+++ b/fly-deploy/worker-temporal-routing.toml
@@ -1,0 +1,16 @@
+app = "corpus-temporal-routing"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/workers/Dockerfile"
+
+[processes]
+  worker = "python -m workers.run_temporal_worker --queue document-routing-queue"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/fly-deploy/worker-temporal-workflow.toml
+++ b/fly-deploy/worker-temporal-workflow.toml
@@ -1,0 +1,16 @@
+app = "corpus-temporal-workflow"
+primary_region = "iad"
+
+[build]
+  dockerfile = "backend/workers/Dockerfile"
+
+[processes]
+  worker = "python -m workers.run_workflow_worker"
+
+[env]
+  ENVIRONMENT = "production"
+  STORAGE_PROVIDER = "s3"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"

--- a/scripts/.env.fly.template
+++ b/scripts/.env.fly.template
@@ -1,0 +1,146 @@
+# =============================================================================
+# Fly.io Secrets Template
+# =============================================================================
+# Copy this file to .env.fly and fill in your values.
+# Run: cp scripts/.env.fly.template scripts/.env.fly
+# Then: bash scripts/provision-fly.sh
+#
+# Lines starting with # are ignored. Empty values are skipped.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# DATABASE (Neon Postgres — https://neon.tech)
+# Create a project, copy the connection details from the dashboard.
+# -----------------------------------------------------------------------------
+DB_USER=
+DB_PASSWORD=
+DB_HOST=
+DB_PORT=5432
+DB_NAME=corpus
+
+# -----------------------------------------------------------------------------
+# MESSAGING (CloudAMQP — https://www.cloudamqp.com)
+# Create a free/paid instance. Connection details are on the dashboard.
+# The AMQP URL format is: amqp://user:pass@host:port/vhost
+# -----------------------------------------------------------------------------
+RABBITMQ_HOST=
+RABBITMQ_PORT=5672
+RABBITMQ_USERNAME=
+RABBITMQ_PASSWORD=
+RABBITMQ_VHOST=/
+
+# -----------------------------------------------------------------------------
+# CACHE (Fly Redis — https://fly.io/docs/reference/redis/)
+# Create via: fly redis create --region iad
+# Or use Upstash Redis: https://upstash.com
+# -----------------------------------------------------------------------------
+REDIS_HOST=
+REDIS_PORT=6379
+REDIS_PASSWORD=
+
+# -----------------------------------------------------------------------------
+# STORAGE (Cloudflare R2 — https://dash.cloudflare.com → R2)
+# Create a bucket, then create an API token with read/write access.
+# S3_ENDPOINT_URL should be: https://<ACCOUNT_ID>.r2.cloudflarestorage.com
+# -----------------------------------------------------------------------------
+STORAGE_PROVIDER=s3
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=auto
+S3_BUCKET_NAME=corpus
+S3_ENDPOINT_URL=
+
+# -----------------------------------------------------------------------------
+# SEARCH (Turbopuffer — https://turbopuffer.com)
+# Sign up and grab your API key from the dashboard.
+# -----------------------------------------------------------------------------
+DOCUMENT_SEARCH_PROVIDER=turbopuffer
+TURBOPUFFER_API_KEY=
+
+# -----------------------------------------------------------------------------
+# TEMPORAL (Temporal Cloud — https://cloud.temporal.io)
+# Namespace and API key from Temporal Cloud dashboard.
+# Host format: <namespace>.<account>.tmprl.cloud:7233
+# -----------------------------------------------------------------------------
+TEMPORAL_HOST=
+TEMPORAL_NAMESPACE=default
+TEMPORAL_API_KEY=
+
+# -----------------------------------------------------------------------------
+# AI / LLM PROVIDERS
+# -----------------------------------------------------------------------------
+# OpenRouter (https://openrouter.ai) — unified LLM gateway
+OPENROUTER_API_KEY=
+
+# Anthropic (https://console.anthropic.com) — for workflow agents
+ANTHROPIC_API_KEY=
+
+# OpenAI (https://platform.openai.com) — for embeddings
+# JSON array format: ["sk-key1","sk-key2"]
+OPENAI_API_KEYS=
+
+# Google Gemini — JSON array: ["key1","key2"]
+GEMINI_API_KEYS=
+GEMINI_MODEL=gemini-2.0-flash
+
+# Google Cloud (for Speech-to-Text, etc.)
+GOOGLE_PROJECT_ID=
+GOOGLE_REGION=us-central1
+
+# Voyage AI (optional, for voyage embeddings)
+# VOYAGE_API_KEYS=
+
+# -----------------------------------------------------------------------------
+# OBSERVABILITY (Axiom — https://axiom.co)
+# Create a dataset and API token from Settings → API Tokens.
+# -----------------------------------------------------------------------------
+AXIOM_TOKEN=
+AXIOM_DATASET=corpus
+
+# -----------------------------------------------------------------------------
+# EXTERNAL SERVICES
+# -----------------------------------------------------------------------------
+# Vectorize (https://vectorize.io)
+VECTORIZE_API_KEY=
+VECTORIZE_ORGANIZATION_ID=
+
+# DataLab API
+DATALAB_API_KEY=
+
+# Exa Search (https://exa.ai)
+EXA_API_KEY=
+
+# -----------------------------------------------------------------------------
+# AUTH
+# -----------------------------------------------------------------------------
+# Firebase (project ID — falls back to GOOGLE_PROJECT_ID if not set)
+FIREBASE_PROJECT_ID=
+
+# Okta SSO (optional)
+OKTA_ISSUER=
+OKTA_CLIENT_ID=
+
+# Auth0 SSO (optional)
+# AUTH0_DOMAIN=
+# AUTH0_CLIENT_ID=
+# AUTH0_AUDIENCE=
+
+# -----------------------------------------------------------------------------
+# BILLING (Stripe — https://dashboard.stripe.com)
+# -----------------------------------------------------------------------------
+STRIPE_SECRET_KEY=
+STRIPE_PUBLISHABLE_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_PRICE_ID_STARTER=
+STRIPE_PRICE_ID_PROFESSIONAL=
+STRIPE_PRICE_ID_BUSINESS=
+STRIPE_PRICE_ID_ENTERPRISE=
+
+# -----------------------------------------------------------------------------
+# GENERAL
+# -----------------------------------------------------------------------------
+APP_NAME=corpus-api
+API_VERSION=v1
+DEBUG=false
+OTEL_SERVICE_VERSION=1.0.0
+DEFAULT_MODEL=google/gemini-2.0-flash-001

--- a/scripts/.env.fly.template
+++ b/scripts/.env.fly.template
@@ -17,6 +17,7 @@ DB_PASSWORD=
 DB_HOST=
 DB_PORT=5432
 DB_NAME=corpus
+DATABASE_URL=
 
 # -----------------------------------------------------------------------------
 # MESSAGING (CloudAMQP — https://www.cloudamqp.com)
@@ -58,6 +59,14 @@ DOCUMENT_SEARCH_PROVIDER=turbopuffer
 TURBOPUFFER_API_KEY=
 
 # -----------------------------------------------------------------------------
+# MODAL (https://modal.com)
+# Run: modal token new --profile <your-app>
+# Credentials are written to ~/.modal.toml
+# -----------------------------------------------------------------------------
+MODAL_TOKEN_ID=
+MODAL_TOKEN_SECRET=
+
+# -----------------------------------------------------------------------------
 # TEMPORAL (Temporal Cloud — https://cloud.temporal.io)
 # Namespace and API key from Temporal Cloud dashboard.
 # Host format: <namespace>.<account>.tmprl.cloud:7233
@@ -84,7 +93,7 @@ GEMINI_API_KEYS=
 GEMINI_MODEL=gemini-2.0-flash
 
 # Google Cloud (for Speech-to-Text, etc.)
-GOOGLE_PROJECT_ID=
+GOOGLE_PROJECT_ID=corpus-prod
 GOOGLE_REGION=us-central1
 
 # Voyage AI (optional, for voyage embeddings)

--- a/scripts/provision-fly.sh
+++ b/scripts/provision-fly.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Fly.io Provisioning Script
+# Creates all Corpus apps and sets secrets from .env.fly
+#
+# Usage:
+#   bash scripts/provision-fly.sh              # Full provisioning
+#   bash scripts/provision-fly.sh --dry-run    # Print what would happen
+#   bash scripts/provision-fly.sh --secrets    # Only set secrets (apps exist)
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env.fly"
+REGION="iad"
+ORG="${FLY_ORG:-personal}"
+
+DRY_RUN=false
+SECRETS_ONLY=false
+
+for arg in "$@"; do
+    case $arg in
+        --dry-run) DRY_RUN=true ;;
+        --secrets) SECRETS_ONLY=true ;;
+    esac
+done
+
+# -- Colors --
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}[INFO]${NC} $1"; }
+ok()    { echo -e "${GREEN}[OK]${NC} $1"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $1"; }
+err()   { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# -- App definitions --
+ALL_APPS=(
+    corpus-api
+    corpus-agent
+    corpus-worker-qa
+    corpus-worker-document-indexing
+    corpus-temporal-routing
+    corpus-temporal-pdf
+    corpus-temporal-page
+    corpus-temporal-generic
+    corpus-temporal-chunking
+    corpus-temporal-workflow
+    corpus-temporal-qa
+)
+
+# Per-app Temporal task queues (app_name:queue_name)
+get_task_queue() {
+    case "$1" in
+        corpus-temporal-routing)   echo "document-routing-queue" ;;
+        corpus-temporal-pdf)       echo "pdf-processing-queue" ;;
+        corpus-temporal-page)      echo "page-processing-queue" ;;
+        corpus-temporal-generic)   echo "generic-processing-queue" ;;
+        corpus-temporal-chunking)  echo "chunking-queue" ;;
+        corpus-temporal-workflow)  echo "workflow-execution-queue" ;;
+        corpus-temporal-qa)        echo "qa-processing-queue" ;;
+        *)                         echo "" ;;
+    esac
+}
+
+# -- Preflight checks --
+preflight() {
+    if ! command -v fly &>/dev/null; then
+        err "flyctl not installed. Install: curl -L https://fly.io/install.sh | sh"
+        exit 1
+    fi
+
+    if ! fly auth whoami &>/dev/null; then
+        err "Not logged in to Fly. Run: fly auth login"
+        exit 1
+    fi
+
+    if [[ ! -f "$ENV_FILE" ]]; then
+        err "Missing $ENV_FILE"
+        echo ""
+        echo "  cp scripts/.env.fly.template scripts/.env.fly"
+        echo "  # Fill in your values, then re-run this script."
+        echo ""
+        exit 1
+    fi
+
+    ok "flyctl installed and authenticated"
+    ok "Found $ENV_FILE"
+}
+
+# -- Parse .env.fly into secrets string --
+parse_env_file() {
+    local secrets=""
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Skip comments and blank lines
+        [[ "$line" =~ ^#.*$ ]] && continue
+        [[ -z "$line" ]] && continue
+        # Skip lines without =
+        [[ "$line" != *"="* ]] && continue
+
+        local key="${line%%=*}"
+        local val="${line#*=}"
+
+        # Skip empty values
+        [[ -z "$val" ]] && continue
+
+        secrets+="${key}=${val} "
+    done < "$ENV_FILE"
+
+    echo "$secrets"
+}
+
+# -- Create apps --
+create_apps() {
+    info "Creating ${#ALL_APPS[@]} Fly apps in region $REGION..."
+    echo ""
+
+    for app in "${ALL_APPS[@]}"; do
+        if fly apps list --json 2>/dev/null | grep -q "\"$app\""; then
+            ok "$app already exists"
+        else
+            if $DRY_RUN; then
+                info "[DRY RUN] fly apps create $app --org $ORG"
+            else
+                fly apps create "$app" --org "$ORG" 2>/dev/null && ok "Created $app" || warn "$app may already exist"
+            fi
+        fi
+    done
+    echo ""
+}
+
+# -- Set shared secrets --
+set_secrets() {
+    local secrets
+    secrets=$(parse_env_file)
+
+    if [[ -z "$secrets" ]]; then
+        err "No secrets parsed from $ENV_FILE — is it filled in?"
+        exit 1
+    fi
+
+    # Count secrets
+    local count
+    count=$(echo "$secrets" | tr ' ' '\n' | grep -c '=' || true)
+    info "Setting $count shared secrets across ${#ALL_APPS[@]} apps..."
+    echo ""
+
+    for app in "${ALL_APPS[@]}"; do
+        # Build per-app secrets (shared + app-specific)
+        local app_secrets="$secrets"
+
+        # Add OTEL service name (same as app name)
+        app_secrets+="OTEL_SERVICE_NAME=${app} "
+
+        # Add Temporal task queue (only for temporal workers)
+        local queue
+        queue=$(get_task_queue "$app")
+        if [[ -n "$queue" ]]; then
+            app_secrets+="TEMPORAL_TASK_QUEUE=${queue} "
+        fi
+
+        # Add environment + execution mode
+        app_secrets+="ENVIRONMENT=production "
+        app_secrets+="WORKFLOW_EXECUTION_MODE=modal "
+
+        # API endpoint for Fly internal networking
+        app_secrets+="API_ENDPOINT=http://corpus-api.internal:8000 "
+
+        if $DRY_RUN; then
+            info "[DRY RUN] fly secrets set <${count}+ secrets> -a $app"
+        else
+            echo "$app_secrets" | xargs fly secrets set -a "$app" --stage 2>/dev/null \
+                && ok "$app — secrets staged" \
+                || warn "$app — failed to set secrets"
+        fi
+    done
+    echo ""
+}
+
+# -- Deploy secrets (unstage) --
+deploy_secrets() {
+    info "Deploying staged secrets..."
+    echo ""
+    for app in "${ALL_APPS[@]}"; do
+        if $DRY_RUN; then
+            info "[DRY RUN] fly secrets deploy -a $app"
+        else
+            fly secrets deploy -a "$app" 2>/dev/null \
+                && ok "$app — secrets deployed" \
+                || warn "$app — no staged secrets or deploy failed (ok if app has no machines yet)"
+        fi
+    done
+    echo ""
+}
+
+# -- Summary --
+summary() {
+    echo ""
+    echo "============================================="
+    echo -e "${GREEN} Provisioning complete!${NC}"
+    echo "============================================="
+    echo ""
+    echo "Apps created:"
+    for app in "${ALL_APPS[@]}"; do
+        echo "  - $app"
+    done
+    echo ""
+    echo "Next steps:"
+    echo "  1. Verify:  fly apps list"
+    echo "  2. Check:   fly secrets list -a corpus-api"
+    echo "  3. Deploy:  git push (triggers .github/workflows/deploy-fly.yaml)"
+    echo "     Or manually: fly deploy -a corpus-api --config fly-deploy/api.toml --image <image>"
+    echo ""
+    echo "External services checklist:"
+    echo "  [ ] Neon Postgres — https://neon.tech"
+    echo "  [ ] CloudAMQP     — https://www.cloudamqp.com"
+    echo "  [ ] Cloudflare R2 — https://dash.cloudflare.com → R2"
+    echo "  [ ] Turbopuffer   — https://turbopuffer.com"
+    echo "  [ ] Temporal Cloud — https://cloud.temporal.io"
+    echo "  [ ] Axiom         — https://axiom.co"
+    echo "  [ ] Stripe        — https://dashboard.stripe.com"
+    echo ""
+}
+
+# -- Main --
+main() {
+    echo ""
+    echo "==========================================="
+    echo "  Corpus — Fly.io Provisioning"
+    echo "==========================================="
+    echo ""
+
+    if $DRY_RUN; then
+        warn "DRY RUN MODE — no changes will be made"
+        echo ""
+    fi
+
+    preflight
+
+    if ! $SECRETS_ONLY; then
+        create_apps
+    fi
+
+    set_secrets
+    deploy_secrets
+    summary
+}
+
+main

--- a/scripts/teardown-fly.sh
+++ b/scripts/teardown-fly.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Fly.io Teardown Script
+# Destroys all Corpus Fly apps. USE WITH CAUTION.
+#
+# Usage:
+#   bash scripts/teardown-fly.sh              # Interactive (confirms each app)
+#   bash scripts/teardown-fly.sh --force      # Destroy all without prompting
+# =============================================================================
+set -euo pipefail
+
+FORCE=false
+for arg in "$@"; do
+    case $arg in
+        --force) FORCE=true ;;
+    esac
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+ALL_APPS=(
+    corpus-api
+    corpus-agent
+    corpus-worker-qa
+    corpus-worker-document-indexing
+    corpus-temporal-routing
+    corpus-temporal-pdf
+    corpus-temporal-page
+    corpus-temporal-generic
+    corpus-temporal-chunking
+    corpus-temporal-workflow
+    corpus-temporal-qa
+)
+
+echo ""
+echo -e "${RED}==========================================="
+echo "  Corpus — Fly.io TEARDOWN"
+echo -e "===========================================${NC}"
+echo ""
+echo "This will DESTROY the following apps:"
+for app in "${ALL_APPS[@]}"; do
+    echo "  - $app"
+done
+echo ""
+
+if ! $FORCE; then
+    read -rp "Type 'destroy' to confirm: " confirm
+    if [[ "$confirm" != "destroy" ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+for app in "${ALL_APPS[@]}"; do
+    if fly apps list --json 2>/dev/null | grep -q "\"$app\""; then
+        fly apps destroy "$app" --yes 2>/dev/null \
+            && echo -e "${GREEN}[OK]${NC} Destroyed $app" \
+            || echo -e "${YELLOW}[WARN]${NC} Failed to destroy $app"
+    else
+        echo -e "${YELLOW}[SKIP]${NC} $app does not exist"
+    fi
+done
+
+echo ""
+echo -e "${GREEN}Teardown complete.${NC}"


### PR DESCRIPTION
## Summary
- Replaces GKE/GCP infrastructure with Fly.io for all services
- Adds Modal executor for agent jobs (replaces K8s Jobs + gVisor)
- Adds Turbopuffer providers for document/vector/keyword search (replaces Elasticsearch)
- Adds Fly deploy CI/CD workflow (replaces Terraform + Helm + Tailscale)
- Adds provisioning scripts and fly.toml configs for all 11 services

## Cost
~$45-135/mo vs ~$200-350/mo on GCP

## Test plan
- [ ] Run `bash scripts/provision-fly.sh --secrets` to push updated secrets to Fly
- [ ] Merge to main to trigger `deploy-fly.yaml`
- [ ] Verify all 11 apps deploy successfully on Fly
- [ ] Run DB migrations via CI
- [ ] Smoke test: document upload → extraction → chunking → search → QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)