### PR TITLE
Fix GHCR auth for Fly image pulls

### DIFF
--- a/.github/workflows/deploy-fly.yaml
+++ b/.github/workflows/deploy-fly.yaml
@@ -115,6 +115,15 @@ jobs:
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Register GHCR credentials with Fly
+        run: |
+          flyctl registry save \
+            --registry ghcr.io \
+            --username ${{ github.actor }} \
+            --password ${{ secrets.GHCR_TOKEN }}
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
       - name: Run database migrations
         run: |
           flyctl machines run \


### PR DESCRIPTION
## Summary
- Use `GHCR_TOKEN` PAT (with `read:packages`) instead of `GITHUB_TOKEN` for `fly registry save`
- `GITHUB_TOKEN` expires after each workflow run; Fly needs long-lived credentials to pull images

## Required
Add `GHCR_TOKEN` to repo secrets (Settings → Secrets → Actions) with a classic PAT that has `read:packages` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)