### PR TITLE
Fix: disable buildx provenance to allow push to Fly registry

### DIFF
--- a/.github/workflows/deploy-fly.yaml
+++ b/.github/workflows/deploy-fly.yaml
@@ -93,6 +93,7 @@ jobs:
           context: .
           file: ${{ matrix.image.dockerfile }}
           push: true
+          provenance: false
           tags: |
             ${{ env.GHCR }}/${{ matrix.image.name }}:${{ needs.setup.outputs.version_tag }}
             ${{ env.GHCR }}/${{ matrix.image.name }}:latest
@@ -106,6 +107,7 @@ jobs:
           context: .
           file: ${{ matrix.image.dockerfile }}
           push: true
+          provenance: false
           tags: |
             ${{ env.GHCR }}/${{ matrix.image.name }}:${{ needs.setup.outputs.version_tag }}
             ${{ env.GHCR }}/${{ matrix.image.name }}:latest


### PR DESCRIPTION
## Summary
`docker/build-push-action` adds OCI provenance attestation manifests by default. Fly's registry rejects these with `unknown: app repository not found`. Adding `provenance: false` disables attestation and allows the push to succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)