### PR TITLE
fix: api memory 1gb + deploy fail-fast false

### DIFF
--- a/.github/workflows/deploy-fly.yaml
+++ b/.github/workflows/deploy-fly.yaml
@@ -119,6 +119,7 @@ jobs:
     needs: [setup, build-and-push]
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         service:
           - name: corpus-api

--- a/fly-deploy/api.toml
+++ b/fly-deploy/api.toml
@@ -32,4 +32,4 @@ primary_region = "iad"
 
 [[vm]]
   size = "shared-cpu-1x"
-  memory = "512mb"
+  memory = "1gb"


### PR DESCRIPTION
- Bump corpus-api VM memory 512mb → 1gb (OOM with 2 gunicorn workers)
- Add `fail-fast: false` on deploy matrix so one failure doesn't cancel all 11 deploys