### PR TITLE
fix: COOP header for Firebase auth popup

### DIFF
--- a/vite/public/_headers
+++ b/vite/public/_headers
@@ -1,0 +1,2 @@
+/*
+  Cross-Origin-Opener-Policy: same-origin-allow-popups


### PR DESCRIPTION
Cloudflare Pages doesn't serve nginx.conf headers. Add `_headers` file so Firebase login popup can close.