### PR TITLE
fix: Firebase credentials from JSON secret on Fly

### DIFF
--- a/backend/common/core/config.py
+++ b/backend/common/core/config.py
@@ -114,9 +114,8 @@ class Settings(BaseSettings):
     # Vertex ai
     google_project_id: str
     google_region: str
-    google_application_credentials: Optional[str] = (
-        None  # Optional - falls back to pod identity with Workload Identity
-    )
+    google_application_credentials: Optional[str] = None
+    google_application_credentials_json: Optional[str] = None
 
     # PDF Processing
     pdf_page_split_size: int = 1

--- a/backend/packages/auth/providers/firebase_provider.py
+++ b/backend/packages/auth/providers/firebase_provider.py
@@ -1,5 +1,6 @@
 """Firebase Auth provider implementation."""
 
+import json
 from typing import Optional
 
 import firebase_admin
@@ -35,6 +36,10 @@ def _get_firebase_app() -> firebase_admin.App:
         cred = None
         if settings.google_application_credentials:
             cred = credentials.Certificate(settings.google_application_credentials)
+        elif settings.google_application_credentials_json:
+            cred = credentials.Certificate(
+                json.loads(settings.google_application_credentials_json)
+            )
 
         _firebase_app = firebase_admin.initialize_app(
             credential=cred, options={"projectId": project_id}


### PR DESCRIPTION
Add `GOOGLE_APPLICATION_CREDENTIALS_JSON` settings field so Firebase Admin SDK can load credentials on Fly (no filesystem access, no Workload Identity).