### PR TITLE
fix: surface real errors when workflow execution fails

### DIFF
--- a/backend/packages/workflows/routes/workflows.py
+++ b/backend/packages/workflows/routes/workflows.py
@@ -187,6 +187,8 @@ async def execute_workflow(
             started_at=execution.started_at,
         )
 
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/vite/src/components/workflows/workflows-tab-content.tsx
+++ b/vite/src/components/workflows/workflows-tab-content.tsx
@@ -63,6 +63,7 @@ export function WorkflowsTabContent({ workspaceId }: WorkflowsTabContentProps) {
           authorization: `Bearer ${token}`,
         },
       })
+      if (response.error) throw response.error
       return response.data
     },
     onSuccess: (data: ExecutionStartedResponse | undefined) => {


### PR DESCRIPTION
## Summary
- Re-raise `HTTPException` before the generic `except Exception` handler in `execute_workflow` so 429 quota errors aren't swallowed and returned as 500s
- Check `response.error` in the frontend `mutationFn` so `onError` fires correctly instead of `onSuccess` with `undefined` data (was showing "Execution ID: undefined" in the toast)

## Test plan
- [ ] Trigger a workflow on a FREE tier account — should now get a proper "Monthly workflow limit reached" error toast instead of "Execution ID: undefined"
- [ ] Trigger a workflow on a paid account — should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)