### PR TITLE
fix: pass extracted content to Turbopuffer and raise on index failure

### DIFF
--- a/backend/packages/documents/workers/document_indexing_worker.py
+++ b/backend/packages/documents/workers/document_indexing_worker.py
@@ -63,23 +63,21 @@ class DocumentIndexingWorker(BaseWorker[DocumentIndexingMessage]):
                 f"Indexing document: {document.filename} (extraction_status: {document.extraction_status})"
             )
 
-            # Index document in search provider
-            # This will index basic metadata immediately, and content if extraction is complete
-            await search_provider.index_document(document)
-            logger.info(
-                f"Successfully indexed document {document_id} in search provider"
-            )
-
-            # If document has extracted content, also index the content
+            # Download extracted content if available
+            extracted_content = None
             if (
                 document.extraction_status == ExtractionStatus.COMPLETED
                 and document.extracted_content_path
             ):
-                logger.info(
-                    f"Document {document_id} has extracted content, indexing full content"
-                )
-                # The search provider's index_document method should handle both metadata and content
-                # based on the document's extraction status
+                extracted_content = await document_service.get_extracted_content(document)
+                if extracted_content:
+                    logger.info(f"Document {document_id} has {len(extracted_content)} chars of extracted content to index")
+
+            # Index document in search provider (metadata + content)
+            success = await search_provider.index_document(document, extracted_content)
+            if not success:
+                raise RuntimeError(f"Search provider failed to index document {document_id}")
+            logger.info(f"Successfully indexed document {document_id} in search provider")
 
             # Mark job as completed
             await indexing_job_service.update_job_status(

--- a/backend/packages/workflows/routes/workflows.py
+++ b/backend/packages/workflows/routes/workflows.py
@@ -187,6 +187,8 @@ async def execute_workflow(
             started_at=execution.started_at,
         )
 
+    except HTTPException:
+        raise
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except Exception as e:

--- a/vite/src/components/workflows/workflows-tab-content.tsx
+++ b/vite/src/components/workflows/workflows-tab-content.tsx
@@ -63,6 +63,7 @@ export function WorkflowsTabContent({ workspaceId }: WorkflowsTabContentProps) {
           authorization: `Bearer ${token}`,
         },
       })
+      if (response.error) throw response.error
       return response.data
     },
     onSuccess: (data: ExecutionStartedResponse | undefined) => {


### PR DESCRIPTION
## Summary
- Worker was ignoring the boolean return value of `index_document` — jobs were being marked **completed** even when Turbopuffer returned an error
- Extracted content was never passed to the search provider — the code detected it but had a dead comment instead of actual logic, so full-text search had no content to index
- Now downloads extracted content via `document_service.get_extracted_content` when available and passes it through to `index_document`
- Raises `RuntimeError` if the provider returns `False` so the job is properly marked failed

## Test plan
- [ ] Merge and deploy, then re-upload a document
- [ ] Verify Turbopuffer namespace appears with document metadata + extracted content

🤖 Generated with [Claude Code](https://claude.com/claude-code)